### PR TITLE
Cursor keys in tables without modifiers #71

### DIFF
--- a/SIDFactoryII/source/foundation/input/keyboard_utils.cpp
+++ b/SIDFactoryII/source/foundation/input/keyboard_utils.cpp
@@ -15,6 +15,8 @@ namespace Foundation
 				return false;
 			if (static_cast<bool>(inModifiersToCheckAgainst & Keyboard::Alt) != static_cast<bool>(inModifierMask & Keyboard::Alt))
 				return false;
+			if (static_cast<bool>(inModifiersToCheckAgainst & Keyboard::Cmd) != static_cast<bool>(inModifierMask & Keyboard::Cmd))
+				return false;
 
 			return true;
 		}

--- a/SIDFactoryII/source/runtime/editor/components/component_list_selector.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_list_selector.cpp
@@ -43,13 +43,21 @@ namespace Editor
 				switch (key_event)
 				{
 				case SDLK_DOWN:
-					DoCursorDown();
-					m_RequireRefresh = true;
-					return true;
+					if (inKeyboard.IsModifierEmpty())
+					{
+						DoCursorDown();
+						m_RequireRefresh = true;
+						return true;
+					}
+					break;
 				case SDLK_UP:
-					DoCursorUp();
-					m_RequireRefresh = true;
-					return true;
+					if (inKeyboard.IsModifierEmpty())
+					{
+						DoCursorUp();
+						m_RequireRefresh = true;
+						return true;
+					}
+					break;
 				case SDLK_PAGEDOWN:
 					DoPageDown();
 					m_RequireRefresh = true;

--- a/SIDFactoryII/source/runtime/editor/components/component_orderlistoverview.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_orderlistoverview.cpp
@@ -75,14 +75,14 @@ namespace Editor
 			switch(key_event)
 			{
 			case SDLK_DOWN:
-				if (DoCursorDown(1))
+				if (inKeyboard.IsModifierEmpty() && DoCursorDown(1))
 				{
 					m_RequireRefresh = true;
 					consume = true;
 				}
 				break;
 			case SDLK_UP:
-				if (DoCursorUp(1))
+				if (inKeyboard.IsModifierEmpty() && DoCursorUp(1))
 				{
 					m_RequireRefresh = true;
 					consume = true;

--- a/SIDFactoryII/source/runtime/editor/components/component_table_row_elements.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_table_row_elements.cpp
@@ -154,7 +154,7 @@ namespace Editor
 						}
 						break;
 					case SDLK_RIGHT:
-					if (inKeyboard.IsModifierEmpty())
+						if (inKeyboard.IsModifierEmpty())
 						{
 							m_CursorX = m_CursorX < m_MaxCursorX ? (m_CursorX + 1) : m_MaxCursorX;
 							consume = true;
@@ -168,11 +168,11 @@ namespace Editor
 						}
 						break;
 					case SDLK_DOWN:
-					if (inKeyboard.IsModifierEmpty())
-					{
-						DoCursorDown();
-						consume = true;
-					}
+						if (inKeyboard.IsModifierEmpty())
+						{
+							DoCursorDown();
+							consume = true;
+						}
 						break;
 					case SDLK_INSERT:
 						if (m_InsertDeleteEnabled)

--- a/SIDFactoryII/source/runtime/editor/components/component_table_row_elements.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_table_row_elements.cpp
@@ -147,20 +147,32 @@ namespace Editor
 					switch (key_event)
 					{
 					case SDLK_LEFT:
-						m_CursorX = m_CursorX > 0 ? (m_CursorX - 1) : 0;
-						consume = true;
+						if (inKeyboard.IsModifierEmpty())
+						{
+							m_CursorX = m_CursorX > 0 ? (m_CursorX - 1) : 0;
+							consume = true;
+						}
 						break;
 					case SDLK_RIGHT:
-						m_CursorX = m_CursorX < m_MaxCursorX ? (m_CursorX + 1) : m_MaxCursorX;
-						consume = true;
+					if (inKeyboard.IsModifierEmpty())
+						{
+							m_CursorX = m_CursorX < m_MaxCursorX ? (m_CursorX + 1) : m_MaxCursorX;
+							consume = true;
+						}
 						break;
 					case SDLK_UP:
-						DoCursorUp();
-						consume = true;
+						if (inKeyboard.IsModifierEmpty())
+						{
+							DoCursorUp();
+							consume = true;
+						}
 						break;
 					case SDLK_DOWN:
+					if (inKeyboard.IsModifierEmpty())
+					{
 						DoCursorDown();
 						consume = true;
+					}
 						break;
 					case SDLK_INSERT:
 						if (m_InsertDeleteEnabled)


### PR DESCRIPTION
**Work in progress**

Cursor keys in tables work only without modifiers,
so we can map up/down with modifiers to other functions

Fixes #71 

Open issues:
- ~~up/down (arrows without modifier) in the song order overview now also triggers instrument up/down (arrows with Cmd modifier). Weird because the modifier is not pressed.~~
- Assumes that the arrow keys are never layed out on the keyboard so that a modifier is needed to access them (see general issue below)

General issue:
There is a general issue with mapping keys for different keyboards; if the key I want to map happens to share the same key with another key, I have to use the modifier. For example the + key is above the = on my keyboard. So I have to map SDLK_EQUALS with modifier Shift. This doesn't work when the keyboard layout is different and the + key is somewhere else. This makes it almost impossible to map keys that share the same key.
Not sure if this is an SDL thing, or if it's the way we implemented key handling.

