### PR TITLE
Fixed detection of int type in config value

### DIFF
--- a/SIDFactoryII/source/utils/config/configtypes.cpp
+++ b/SIDFactoryII/source/utils/config/configtypes.cpp
@@ -171,7 +171,7 @@ namespace Utility
 				if (length <= 2)
 					return false;
 
-				if (inValue[0] != '0' && inValue[1] != 'x')
+				if (!(inValue[0] == '0' && inValue[1] == 'x'))
 					return false;
 
 				for (size_t i = 2; i < length; ++i)


### PR DESCRIPTION
Float values like 0.2, 0.6 etc were wrongly detected as int values.