### PR TITLE
Added user.default.ini with some basic configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
 
 ## Changelog
 
+- Added: Documentation on how to customize configuration using a user.ini file.
+  Including a default template.
+
+
 ### Build 20210104
 
 #### Editor

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -179,6 +179,10 @@ Key.Track.SetOrderlistLoopPoint                     = @l:shift:control
 
 #include "~/.config/sidfactory2/user.ini"
 
+[linux]     // Applies to the linux platform only
+
+#include "~/.config/sidfactory2/user.ini"
+
 //
 // KEY OVERRIDES FOR MAC VERSION ONLY
 //

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -15,7 +15,7 @@
 
 //
 // SOUND OPTIONS
-// 
+//
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 
@@ -34,7 +34,7 @@ Editor.Driver.ConvertLegacyColors   = 1         // DEPRECATED - this will be del
 //
 // OVERLAY
 //
-Show.Overlay                        = 1         // If you set this to 1, the overlay will be shown when starting the editor.
+Show.Overlay                        = 0         // If you set this to 1, the overlay will be shown when starting the editor.
 
                                                 // Note that you can always toggle the overlay on and off with the F12 hotkey.
 

--- a/SIDFactoryII/source/runtime/editor/overlay_control.cpp
+++ b/SIDFactoryII/source/runtime/editor/overlay_control.cpp
@@ -1,12 +1,12 @@
 #include "runtime/editor/overlay_control.h"
+#include "foundation/base/types.h"
+#include "foundation/graphics/viewport.h"
+#include "foundation/platform/iplatform.h"
+#include "libraries/ghc/fs_std.h"
+#include "libraries/picopng/picopng.h"
 #include "runtime/editor/driver/driver_info.h"
 #include "utils/configfile.h"
 #include "utils/utilities.h"
-#include "libraries/picopng/picopng.h"
-#include "libraries/ghc/fs_std.h"
-#include "foundation/platform/iplatform.h"
-#include "foundation/graphics/viewport.h"
-#include "foundation/base/types.h"
 #include <algorithm>
 
 
@@ -17,7 +17,7 @@ namespace Editor
 	using namespace Utility::Config;
 
 	OverlayControl::OverlayControl(const Utility::ConfigFile& inConfigFile, Foundation::Viewport* inViewport, const Foundation::IPlatform* inPlatform)
-		: m_Enabled(false)
+		: m_Enabled(GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "Show.Overlay", 0) != 0)
 		, m_OverlayEnabledState(false)
 		, m_Viewport(inViewport)
 		, m_IsFading(true)
@@ -27,7 +27,6 @@ namespace Editor
 		EnumeratePlatformFiles(inPlatform);
 		path overlays_path = inPlatform->Storage_GetOverlaysHomePath();
 		LoadOverlay(true, (overlays_path / (inPlatform->GetName() + "_editor.png")).string());
-		SetOverlayEnabled(GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "Show.Overlay", 0) != 0);
 	}
 
 
@@ -135,7 +134,6 @@ namespace Editor
 	}
 
 
-
 	void OverlayControl::ReadConfigValues(const Utility::ConfigFile& inConfigFile)
 	{
 		m_OverlayWidth = Utility::GetSingleConfigurationValue<Utility::Config::ConfigValueInt>(inConfigFile, "Overlay.Width", 0);
@@ -162,7 +160,7 @@ namespace Editor
 
 			if (is_regular_file(path, error_code))
 			{
-				if(path.path().filename().string().find(platform_name) != std::string::npos)
+				if (path.path().filename().string().find(platform_name) != std::string::npos)
 					m_OverlayFileList.push_back(path.path().string());
 			}
 		}
@@ -187,12 +185,11 @@ namespace Editor
 			if (PicoPNG::decodePNG(decoded_image, decoded_image_width, decoded_image_height, static_cast<const unsigned char*>(file_buffer), file_size, true) == 0)
 			{
 				unsigned char* data = new unsigned char[decoded_image.size()];
-				
+
 				for (unsigned int i = 0; i < decoded_image.size(); ++i)
 					data[i] = decoded_image[i];
-			
-				Rect rect = 
-				{
+
+				Rect rect = {
 					inIsEditorOverlay ? m_OverlayEditorImageX : m_OverlayDriverImageX,
 					inIsEditorOverlay ? m_OverlayEditorImageY : m_OverlayDriverImageY,
 					static_cast<int>(decoded_image_width),

--- a/SIDFactoryII/user.default.ini
+++ b/SIDFactoryII/user.default.ini
@@ -1,0 +1,34 @@
+//
+// user.ini - custom settings for SID Factory II
+//
+// The values in this template are the defaults that will be used when there is no user.ini present.
+//
+// On Windows, rename this file to user.ini and put it in the same folder as config.ini
+//
+// On macOS and linux, put this configuration in the file ~/.config/sidfactory2/user.ini, where ~ is your home directory.
+
+[default]
+
+//
+// SOUND OPTIONS
+// 
+Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear
+                                                // interpolation. Resampling is the best quality possible but also requires more CPU power.
+
+Sound.Buffer.Size                   = 256       // This should always be a power of two. The smallest size possible is 128. If you experience a
+
+                                                // stuttering sound when playing back sound in the editor, try increasing this.
+//
+// EDITOR OPTIONS
+//
+
+Editor.Skip.Intro                   = 0         // If you set this to 1, the black intro screen with logo and credits will never be shown.
+
+//
+// OVERLAY
+//
+Show.Overlay                        = 1         // If you set this to 1, the overlay will be shown when starting the editor.
+
+                                                // Note that you can always toggle the overlay on and off with the F12 hotkey.
+
+

--- a/SIDFactoryII/user.default.ini
+++ b/SIDFactoryII/user.default.ini
@@ -11,7 +11,7 @@
 
 //
 // SOUND OPTIONS
-// 
+//
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 
@@ -27,7 +27,7 @@ Editor.Skip.Intro                   = 0         // If you set this to 1, the bla
 //
 // OVERLAY
 //
-Show.Overlay                        = 1         // If you set this to 1, the overlay will be shown when starting the editor.
+Show.Overlay                        = 0         // If you set this to 1, the overlay will be shown when starting the editor.
 
                                                 // Note that you can always toggle the overlay on and off with the F12 hotkey.
 

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -19,6 +19,8 @@ IF ERRORLEVEL 1 EXIT 1
 
 copy /Y SIDFactoryII\config.ini artifacts\
 IF ERRORLEVEL 1 EXIT 1
+copy /Y SIDFactoryII\user.default.ini artifacts\
+IF ERRORLEVEL 1 EXIT 1
 copy /Y SIDFactoryII\COPYING artifacts\
 IF ERRORLEVEL 1 EXIT 1
 copy /Y SIDFactoryII\SDL2.dll artifacts\

--- a/macos/Install.txt
+++ b/macos/Install.txt
@@ -21,3 +21,8 @@ because it is from an unidentified developer. In that case do the following:
 
 - Right click the "SIDFactoryII.app" in your applications folder and select 'Open'.
 - Select 'Open' if macOS asks you if you are sure.
+
+The folder "SIDFactoryII/documentation" contains a template called "user.default.ini".
+Rename this to user.ini and put it in your home directory in the folder .config.
+SIDFactory looks for the file ~/.config/user.ini for custom configuration (where ~
+is your home directory).

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -17,7 +17,7 @@ DMG=$(ARTIFACTS_FOLDER)/$(APP_NAME)_macOS_$(BUILD_NR).dmg
 DMG_RAW=$(ARTIFACTS_FOLDER)/$(APP_NAME)_macOS_$(BUILD_NR)-RAW.dmg
 DMG_CONTENTS=$(ARTIFACTS_FOLDER)/dmg
 DMG_TITLE=$(APP_NAME)
-DMG_SIZE=16384
+DMG_SIZE=20480
 ICONSET=$(ARTIFACTS_FOLDER)/$(APP_NAME).iconset
 ICONS=$(ARTIFACTS_FOLDER)/$(APP_NAME).icns
 
@@ -111,6 +111,7 @@ $(DMG_CONTENTS): $(APP) $(EXE_SF2C) $(ARTIFACTS_FOLDER)/keys.html
 	cp -r Install.txt $(DMG_CONTENTS)
 	cp -r $(PROJECT_ROOT)/music/ ${DMG_CONTENTS}/$(APP_NAME)/music
 	cp -r $(PROJECT_ROOT)/drivers ${DMG_CONTENTS}/$(APP_NAME)/drivers
+	cp -r $(PROJECT_ROOT)/user.default.ini ${DMG_CONTENTS}/$(APP_NAME)/documentation
 	ln -s /Applications $(DMG_CONTENTS)/Applications
 
 # Make a temporary DMG. This needs to be layed out nicely by hand before building the final DMG.


### PR DESCRIPTION
To release config-only features, like window scaling, audio gain etc. we have to show the user how to use a custom user.ini
For now I have just put the basic stuff in there to keep it manageable.
Also stuff like setting the default colorscheme is not in there yet because on macOS, the colorschemes are packed inside the app. We might think of a solution for this that changes the way the config works.