### PR TITLE
A global singleton for config

### DIFF
--- a/SIDFactoryII/main.cpp
+++ b/SIDFactoryII/main.cpp
@@ -8,20 +8,21 @@
 #include "foundation/platform/platform_factory.h"
 #include "libraries/picopng/picopng.h"
 #include "runtime/editor/editor_facility.h"
-#include "utils/global.h"
 #include "utils/config/configtypes.h"
 #include "utils/configfile.h"
 #include "utils/delegate.h"
 #include "utils/event.h"
+#include "utils/global.h"
 #include "utils/keyhookstore.h"
 #include "utils/logging.h"
 #include "utils/utilities.h"
 
 using namespace Foundation;
 using namespace Editor;
+using namespace Utility;
 
 // Forward declaration
-void Run(IPlatform& inPlatform, int inArgc, char* inArgv[]);
+void Run(const IPlatform& inPlatform, int inArgc, char* inArgv[]);
 void BuildResource();
 
 // Functions
@@ -58,14 +59,13 @@ int main(int inArgc, char* inArgv[])
 	// IPlatform* platform = Foundation::CreatePlatform();
 	Utility::Global config = Utility::Global::instance();
 
-	const IPlatform& platform = *config.m_Platform;
+	const IPlatform& platform = config.GetPlatform();
 
 	// Run the editor
 	Run(platform, inArgc, inArgv);
 
 	// Destroy the platform
 	config.deletePlatform();
-	// delete platform;
 
 	// Close down SDL
 	SDL_Quit();
@@ -74,22 +74,15 @@ int main(int inArgc, char* inArgv[])
 }
 
 
-void Run(IPlatform& inPlatform, int inArgc, char* inArgv[])
+void Run(const IPlatform& inPlatform, int inArgc, char* inArgv[])
 {
-	// Read the config file
-	std::vector<std::string> valid_configuration_sections;
-	valid_configuration_sections.push_back("default");
-	valid_configuration_sections.push_back(inPlatform.GetName());
-#ifdef _DEBUG
-	valid_configuration_sections.push_back("debug");
-#endif //
-
-	std::string config_path = inPlatform.Storage_GetConfigHomePath();
-	Utility::ConfigFile configFile(inPlatform, config_path + "config.ini", valid_configuration_sections);
 
 	// Create viewport (client view size)
 	const int width = 1280;
 	const int height = 720;
+
+	const ConfigFile configFile = Global::instance().GetConfig();
+
 	float window_scaling = Utility::GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(configFile, "Window.Scaling", 1.0);
 
 	if (window_scaling > 2.0)
@@ -110,7 +103,7 @@ void Run(IPlatform& inPlatform, int inArgc, char* inArgv[])
 	Keyboard keyboard;
 
 	// Editor facility
-	EditorFacility editor(&inPlatform, &viewport, configFile);
+	EditorFacility editor(&viewport);
 
 	// Start editor
 	editor.Start(inArgc > 1 ? inArgv[1] : nullptr);

--- a/SIDFactoryII/main.cpp
+++ b/SIDFactoryII/main.cpp
@@ -8,6 +8,7 @@
 #include "foundation/platform/platform_factory.h"
 #include "libraries/picopng/picopng.h"
 #include "runtime/editor/editor_facility.h"
+#include "utils/global.h"
 #include "utils/config/configtypes.h"
 #include "utils/configfile.h"
 #include "utils/delegate.h"
@@ -53,14 +54,18 @@ int main(int inArgc, char* inArgv[])
 
 	Utility::Logging::instance().Info("SIDFactoryII %s build %s", os, build_number);
 
-	// Create the platform
-	IPlatform* platform = Foundation::CreatePlatform();
+	// Create the global config
+	// IPlatform* platform = Foundation::CreatePlatform();
+	Utility::Global config = Utility::Global::instance();
+
+	const IPlatform& platform = *config.m_Platform;
 
 	// Run the editor
-	Run(*platform, inArgc, inArgv);
+	Run(platform, inArgc, inArgv);
 
 	// Destroy the platform
-	delete platform;
+	config.deletePlatform();
+	// delete platform;
 
 	// Close down SDL
 	SDL_Quit();

--- a/SIDFactoryII/main.cpp
+++ b/SIDFactoryII/main.cpp
@@ -33,16 +33,6 @@ int main(int inArgc, char* inArgv[])
 	const char* build_number = __DATE__;
 #endif
 
-#ifdef _SF2_WINDOWS
-	const char* os = "Windows";
-#else
-#ifdef _SF2_LINUX
-	const char* os = "Linux";
-#else
-	const char* os = "macOS";
-#endif
-#endif
-
 	// Initialize SDL
 	const int sdl_init_result = SDL_Init(SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_VIDEO);
 	if (sdl_init_result < 0)
@@ -52,18 +42,16 @@ int main(int inArgc, char* inArgv[])
 		return -1;
 	}
 
-	Utility::Logging::instance().Info("SIDFactoryII %s build %s", os, build_number);
-
-	// Create the global config
-	Utility::Global& global = Utility::Global::instance();
+	Global& global = Utility::Global::instance();
 
 	const IPlatform& platform = global.GetPlatform();
+	Logging::instance().Info("SIDFactoryII %s build %s", platform.GetName().c_str(), build_number);
 
 	// Run the editor
 	Run(platform, inArgc, inArgv);
 
 	// Destroy the platform
-	// TODO: needed? Or deconstructor needed?
+	// TODO: needed? Or use deconstructor?
 	global.deletePlatform();
 
 	// Close down SDL
@@ -213,5 +201,3 @@ void Run(const IPlatform& inPlatform, int inArgc, char* inArgv[])
 	// Stop editor
 	editor.Stop();
 }
-
-

--- a/SIDFactoryII/main.cpp
+++ b/SIDFactoryII/main.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <string>
 
@@ -56,16 +55,16 @@ int main(int inArgc, char* inArgv[])
 	Utility::Logging::instance().Info("SIDFactoryII %s build %s", os, build_number);
 
 	// Create the global config
-	// IPlatform* platform = Foundation::CreatePlatform();
-	Utility::Global config = Utility::Global::instance();
+	Utility::Global& global = Utility::Global::instance();
 
-	const IPlatform& platform = config.GetPlatform();
+	const IPlatform& platform = global.GetPlatform();
 
 	// Run the editor
 	Run(platform, inArgc, inArgv);
 
 	// Destroy the platform
-	config.deletePlatform();
+	// TODO: needed? Or deconstructor needed?
+	global.deletePlatform();
 
 	// Close down SDL
 	SDL_Quit();
@@ -81,7 +80,7 @@ void Run(const IPlatform& inPlatform, int inArgc, char* inArgv[])
 	const int width = 1280;
 	const int height = 720;
 
-	const ConfigFile configFile = Global::instance().GetConfig();
+	const ConfigFile& configFile = Global::instance().GetConfig();
 
 	float window_scaling = Utility::GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(configFile, "Window.Scaling", 1.0);
 
@@ -216,7 +215,3 @@ void Run(const IPlatform& inPlatform, int inArgc, char* inArgv[])
 }
 
 
-void BuildResource()
-{
-	//Utility::MakeBinaryResourceIncludeFile("logo_test.png", "data_logo.h", "data_logo", "Resource");
-}

--- a/SIDFactoryII/source/foundation/platform/iplatform.h
+++ b/SIDFactoryII/source/foundation/platform/iplatform.h
@@ -14,6 +14,11 @@ namespace Foundation
 		IPlatform() { }
 
 	public: 
+		
+		IPlatform(IPlatform& inOther)  = delete;
+		IPlatform(IPlatform&& inOther)  = delete;
+		IPlatform(const IPlatform& inOther)  = delete;
+
 		virtual ~IPlatform() { }
 
 		virtual std::shared_ptr<IMutex> CreateMutex() = 0;

--- a/SIDFactoryII/source/runtime/editor/editor_facility.cpp
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.cpp
@@ -1,47 +1,48 @@
 #include "runtime/editor/editor_facility.h"
-#include "runtime/editor/utilities/import_utils.h"
-#include "runtime/environmentdefines.h"
-#include "runtime/emulation/cpumos6510.h"
-#include "runtime/emulation/cpumemory.h"
-#include "runtime/emulation/sid/sidproxy.h"
-#include "runtime/execution/executionhandler.h"
-#include "runtime/execution/flightrecorder.h"
-#include "runtime/editor/converters/converterbase.h"
-#include "runtime/editor/screens/screen_base.h"
-#include "runtime/editor/screens/screen_intro.h"
-#include "runtime/editor/screens/screen_edit.h"
-#include "runtime/editor/screens/screen_disk.h"
-#include "runtime/editor/screens/screen_convert.h"
-#include "runtime/editor/screens/screen_edit_utils.h"
-#include "runtime/editor/utilities/editor_utils.h"
+#include "foundation/graphics/textfield.h"
+#include "foundation/graphics/viewport.h"
+#include "foundation/input/keyboard.h"
+#include "foundation/platform/iplatform.h"
+#include "foundation/sound/audiostream.h"
+#include "libraries/ghc/fs_std.h"
 #include "runtime/editor/auxilarydata/auxilary_data_collection.h"
 #include "runtime/editor/auxilarydata/auxilary_data_hardware_preferences.h"
-#include "runtime/editor/editor_types.h"
+#include "runtime/editor/converters/converterbase.h"
 #include "runtime/editor/dialog/dialog_message.h"
 #include "runtime/editor/dialog/dialog_message_yesno.h"
 #include "runtime/editor/dialog/dialog_sid_file_info.h"
-#include "runtime/editor/driver/driver_utils.h"
 #include "runtime/editor/driver/driver_info.h"
-#include "runtime/editor/packer/packer.h"
-#include "runtime/editor/overlay_control.h"
+#include "runtime/editor/driver/driver_utils.h"
+#include "runtime/editor/editor_types.h"
 #include "runtime/editor/keys/keyhook_setup.h"
-#include "foundation/graphics/viewport.h"
-#include "foundation/graphics/textfield.h"
-#include "foundation/platform/iplatform.h"
-#include "foundation/input/keyboard.h"
-#include "foundation/sound/audiostream.h"
-#include "utils/utilities.h"
-#include "utils/configfile.h"
-#include "utils/config/configtypes.h"
-#include "utils/config/configcolors.h"
+#include "runtime/editor/overlay_control.h"
+#include "runtime/editor/packer/packer.h"
+#include "runtime/editor/screens/screen_base.h"
+#include "runtime/editor/screens/screen_convert.h"
+#include "runtime/editor/screens/screen_disk.h"
+#include "runtime/editor/screens/screen_edit.h"
+#include "runtime/editor/screens/screen_edit_utils.h"
+#include "runtime/editor/screens/screen_intro.h"
+#include "runtime/editor/utilities/editor_utils.h"
+#include "runtime/editor/utilities/import_utils.h"
+#include "runtime/emulation/cpumemory.h"
+#include "runtime/emulation/cpumos6510.h"
+#include "runtime/emulation/sid/sidproxy.h"
+#include "runtime/environmentdefines.h"
+#include "runtime/execution/executionhandler.h"
+#include "runtime/execution/flightrecorder.h"
 #include "utils/c64file.h"
+#include "utils/config/configcolors.h"
+#include "utils/config/configtypes.h"
+#include "utils/configfile.h"
+#include "utils/global.h"
 #include "utils/psidfile.h"
-#include "libraries/ghc/fs_std.h"
+#include "utils/utilities.h"
 
 // Converter
-#include "runtime/editor/converters/jch/converter_jch.h"
-#include "runtime/editor/converters/gt/converter_gt.h"
 #include "runtime/editor/converters/cc/converter_cc.h"
+#include "runtime/editor/converters/gt/converter_gt.h"
+#include "runtime/editor/converters/jch/converter_jch.h"
 #include "runtime/editor/converters/mod/converter_mod.h"
 #include "runtime/editor/converters/null/converter_null.h"
 
@@ -56,48 +57,51 @@ using namespace fs;
 
 namespace Editor
 {
-    const unsigned int EditorFacility::DefaultDialogWidth = 100;
+	const unsigned int EditorFacility::DefaultDialogWidth = 100;
 
-	EditorFacility::EditorFacility(IPlatform* inPlatform, Viewport* inViewport, Utility::ConfigFile& inConfigFile)
+	EditorFacility::EditorFacility(Viewport* inViewport)
 		: m_Viewport(inViewport)
-		, m_Platform(inPlatform)
-		, m_ConfigFile(inConfigFile)
 		, m_IsDone(false)
 		, m_CurrentScreen(nullptr)
 		, m_RequestedScreen(nullptr)
 		, m_FlipOverlayState(false)
 		, m_SelectedColorScheme(0)
 	{
+
+		ConfigFile& configFile = Global::instance().GetConfig();
+		IPlatform& platform = Global::instance().GetPlatform();
+
 		// Key setup
-		m_KeyHookSetup.ApplyConfigSettings(inConfigFile);
+		m_KeyHookSetup.ApplyConfigSettings(configFile);
 
 		// Configure colors
-		auto color_scheme_names = GetConfigurationValues<ConfigValueString>(inConfigFile, "ColorScheme.Name", {});
-		auto color_scheme_filenames = GetConfigurationValues<ConfigValueString>(inConfigFile, "ColorScheme.Filename", {});
+		auto color_scheme_names = GetConfigurationValues<ConfigValueString>(configFile, "ColorScheme.Name", {});
+		auto color_scheme_filenames = GetConfigurationValues<ConfigValueString>(configFile, "ColorScheme.Filename", {});
 
 		if (color_scheme_names.size() == color_scheme_filenames.size())
 		{
 			m_ColorSchemeCount = color_scheme_names.size();
-			m_SelectedColorScheme = GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "ColorScheme.Selection", 0);
+			m_SelectedColorScheme = GetSingleConfigurationValue<ConfigValueInt>(configFile, "ColorScheme.Selection", 0);
 
-			ConfigureColorsFromScheme(m_SelectedColorScheme, inConfigFile, *inViewport);
+			ConfigureColorsFromScheme(m_SelectedColorScheme, *inViewport);
 		}
 
 		// Create emulation environment
-		SIDConfiguration sid_configuration;										// Default settings are applicable
+		SIDConfiguration sid_configuration; // Default settings are applicable
 
-		const bool sid_use_resample = GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "Sound.Emulation.Resample", 1) != 0;
+		const bool sid_use_resample = GetSingleConfigurationValue<ConfigValueInt>(configFile, "Sound.Emulation.Resample", 1) != 0;
 		sid_configuration.m_eSampleMethod = sid_use_resample ? SID_SAMPLE_METHOD_RESAMPLE_INTERPOLATE : SID_SAMPLE_METHOD_INTERPOLATE;
 		sid_configuration.m_eModel = SID_MODEL_8580;
 
+
 		m_SIDProxy = new SIDProxy(sid_configuration);
-		m_CPUMemory = new CPUMemory(0x10000, m_Platform);
+		m_CPUMemory = new CPUMemory(0x10000, &platform);
 		m_CPU = new CPUmos6510();
-		m_FlightRecorder = new FlightRecorder(m_Platform, 0x800);
-		m_ExecutionHandler = new ExecutionHandler(m_Platform, m_CPU, m_CPUMemory, m_SIDProxy, m_FlightRecorder, inConfigFile);
+		m_FlightRecorder = new FlightRecorder(&platform, 0x800);
+		m_ExecutionHandler = new ExecutionHandler(&platform, m_CPU, m_CPUMemory, m_SIDProxy, m_FlightRecorder, configFile);
 
 		// Create audio stream
-		const int audio_buffer_size = GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "Sound.Buffer.Size", 256);
+		const int audio_buffer_size = GetSingleConfigurationValue<ConfigValueInt>(configFile, "Sound.Buffer.Size", 256);
 		m_AudioStream = new AudioStream(44100, 16, std::max<const int>(audio_buffer_size, 0x80), m_ExecutionHandler);
 
 		// Create the main text field
@@ -108,7 +112,7 @@ namespace Editor
 		m_DriverInfo = std::make_shared<DriverInfo>();
 
 		// Create overlay control
-		m_OverlayControl = std::make_unique<OverlayControl>(inConfigFile, inViewport, inPlatform);
+		m_OverlayControl = std::make_unique<OverlayControl>(configFile, inViewport, &platform);
 
 		// Create screens
 		m_IntroScreen = std::make_unique<ScreenIntro>(
@@ -119,17 +123,16 @@ namespace Editor
 			m_KeyHookSetup.GetKeyHookStore(),
 			m_DriverInfo,
 			[&]() { OnExitIntroScreen(); },
-			[&]() { OnExitIntroScreenToLoad(); }
-		);
+			[&]() { OnExitIntroScreenToLoad(); });
 
 		m_DiskScreen = std::make_unique<ScreenDisk>(
-			m_Platform,
+			&platform,
 			m_Viewport,
 			m_TextField,
 			&m_CursorControl,
 			m_DisplayState,
 			m_KeyHookSetup.GetKeyHookStore(),
-			m_ConfigFile,
+			configFile,
 			[&](const std::string& inFilenameSelection, FileType inSaveFileType) { OnFilenameSelection(m_DiskScreen.get(), inFilenameSelection, inSaveFileType); },
 			[&]() { OnCancelScreen(m_DiskScreen.get()); });
 
@@ -139,10 +142,9 @@ namespace Editor
 			&m_CursorControl,
 			m_DisplayState,
 			m_KeyHookSetup.GetKeyHookStore(),
-			m_Platform,
+			&platform,
 			[&]() { SetCurrentScreen(m_EditScreen.get()); },
-			[&](ScreenBase* inCallerScreen, const std::string& inPathAndFilename, std::shared_ptr<Utility::C64File> inConversionResult) { return OnConversionSuccess(inCallerScreen, inPathAndFilename, inConversionResult); }
-		);
+			[&](ScreenBase* inCallerScreen, const std::string& inPathAndFilename, std::shared_ptr<Utility::C64File> inConversionResult) { return OnConversionSuccess(inCallerScreen, inPathAndFilename, inConversionResult); });
 
 		// 	bool EditorFacility::OnConversionSuccess(ScreenBase* inCallerScreen, const std::string& inPathAndFilename, std::shared_ptr<Utility::C64File> inConversionResult)
 
@@ -166,14 +168,11 @@ namespace Editor
 			[&]() { OnQuickSave(m_EditScreen.get()); },
 			[&](unsigned short inDestinationAddress) { OnPack(m_EditScreen.get(), inDestinationAddress); },
 			[&]() { m_FlipOverlayState = true; },
-			[&](unsigned int inReconfigureOption) { Reconfigure(inReconfigureOption); }
-		);
+			[&](unsigned int inReconfigureOption) { Reconfigure(inReconfigureOption); });
 
 		// Apply additional configuration to the edit screen
-		m_EditScreen->SetAdditionalConfiguration
-		(
-			GetSingleConfigurationValue<ConfigValueInt>(m_ConfigFile, "Editor.Driver.ConvertLegacyColors", 0) != 0
-		);
+		m_EditScreen->SetAdditionalConfiguration(
+			GetSingleConfigurationValue<ConfigValueInt>(configFile, "Editor.Driver.ConvertLegacyColors", 0) != 0);
 	}
 
 	EditorFacility::~EditorFacility()
@@ -197,8 +196,11 @@ namespace Editor
 		FOUNDATION_ASSERT(m_ExecutionHandler != nullptr);
 		FOUNDATION_ASSERT(m_AudioStream != nullptr);
 
-		const bool file_loaded_successfully = [&]()
-		{
+		IPlatform& platform = Global::instance().GetPlatform();
+		ConfigFile& configFile = Global::instance().GetConfig();
+
+
+		const bool file_loaded_successfully = [&]() {
 			if (inFileToLoad != nullptr)
 			{
 				std::string file_to_load(inFileToLoad);
@@ -211,17 +213,17 @@ namespace Editor
 		// Try to load the driver directly
 		if (!file_loaded_successfully)
 		{
-			std::string default_driver_filename = GetSingleConfigurationValue<ConfigValueString>(m_ConfigFile, "Editor.Driver.Default", std::string("sf2driver11_03.prg"));
-			std::string drivers_folder = m_Platform->Storage_GetDriversHomePath();
+			std::string default_driver_filename = GetSingleConfigurationValue<ConfigValueString>(configFile, "Editor.Driver.Default", std::string("sf2driver11_03.prg"));
+			std::string drivers_folder = platform.Storage_GetDriversHomePath();
 			LoadFile(drivers_folder + default_driver_filename);
 		}
 
-        // After loading, set the current path, so that opening the disk menu will be correct.
-        std::error_code ec;
-        fs::current_path(m_Platform->Storage_GetHomePath(), ec);
-        
-        // Start the intro screen
-		if(GetSingleConfigurationValue<ConfigValueInt>(m_ConfigFile, "Editor.Skip.Intro", 0) == 0)
+		// After loading, set the current path, so that opening the disk menu will be correct.
+		std::error_code ec;
+		fs::current_path(platform.Storage_GetHomePath(), ec);
+
+		// Start the intro screen
+		if (GetSingleConfigurationValue<ConfigValueInt>(configFile, "Editor.Skip.Intro", 0) == 0)
 			SetCurrentScreen(m_IntroScreen.get());
 		else
 		{
@@ -291,8 +293,7 @@ namespace Editor
 	{
 		if (m_CurrentScreen != nullptr)
 		{
-			m_CurrentScreen->TryQuit([&](bool inQuit)
-			{
+			m_CurrentScreen->TryQuit([&](bool inQuit) {
 				if (inQuit)
 					m_IsDone = true;
 			});
@@ -303,8 +304,7 @@ namespace Editor
 	{
 		if (m_CurrentScreen != nullptr)
 		{
-			m_CurrentScreen->TryLoad(inPathAndFilename, [&, path_and_filename = inPathAndFilename](bool inQuit)
-			{
+			m_CurrentScreen->TryLoad(inPathAndFilename, [&, path_and_filename = inPathAndFilename](bool inQuit) {
 				if (LoadFile(path_and_filename))
 					ForceRequestScreen(m_EditScreen.get());
 				else
@@ -322,12 +322,15 @@ namespace Editor
 
 	void EditorFacility::Reconfigure(unsigned int inReconfigureOption)
 	{
+
+		ConfigFile& configFile = Global::instance().GetConfig();
+
 		if (inReconfigureOption == 0)
 		{
-			m_ConfigFile.Reload();
+			configFile.Reload();
 			m_KeyHookSetup.Reset();
-			m_KeyHookSetup.ApplyConfigSettings(m_ConfigFile);
-			ConfigureColorsFromScheme(m_SelectedColorScheme, m_ConfigFile, *m_Viewport);
+			m_KeyHookSetup.ApplyConfigSettings(configFile);
+			ConfigureColorsFromScheme(m_SelectedColorScheme, *m_Viewport);
 
 			m_EditScreen->SetActivationMessage("Reloaded config!");
 			ForceRequestScreen(m_EditScreen.get());
@@ -338,7 +341,7 @@ namespace Editor
 			if (m_SelectedColorScheme >= m_ColorSchemeCount)
 				m_SelectedColorScheme = 0;
 
-			std::string selected_color_scheme_name = ConfigureColorsFromScheme(m_SelectedColorScheme, m_ConfigFile, *m_Viewport);
+			std::string selected_color_scheme_name = ConfigureColorsFromScheme(m_SelectedColorScheme, *m_Viewport);
 
 			if (m_CurrentScreen == m_EditScreen.get())
 			{
@@ -348,7 +351,7 @@ namespace Editor
 		}
 		if (inReconfigureOption == 2)
 		{
-			std::string selected_color_scheme_name = ConfigureColorsFromScheme(m_SelectedColorScheme, m_ConfigFile, *m_Viewport);
+			std::string selected_color_scheme_name = ConfigureColorsFromScheme(m_SelectedColorScheme, *m_Viewport);
 
 			if (m_CurrentScreen == m_EditScreen.get())
 			{
@@ -371,14 +374,13 @@ namespace Editor
 	}
 
 
-
 	//------------------------------------------------------------------------------------------------------------
 
 	void EditorFacility::RequestScreen(ScreenBase* inRequestedScreen)
 	{
 		FOUNDATION_ASSERT(m_RequestedScreen == nullptr);
 
-		if(m_CurrentScreen != inRequestedScreen)
+		if (m_CurrentScreen != inRequestedScreen)
 			m_RequestedScreen = inRequestedScreen;
 	}
 
@@ -424,7 +426,7 @@ namespace Editor
 			{
 				std::shared_ptr<Utility::C64File> c64_file = Utility::C64File::CreateFromPRGData(data, static_cast<unsigned int>(data_size));
 
-				if(c64_file != nullptr)
+				if (c64_file != nullptr)
 					driver_info->Parse(*c64_file);
 			}
 
@@ -465,7 +467,7 @@ namespace Editor
 				m_CPUMemory->SetData(c64_file->GetTopAddress(), c64_file->GetData(), c64_file->GetDataSize());
 				m_CPUMemory->Unlock();
 
-				// Init the execution handler 
+				// Init the execution handler
 				m_ExecutionHandler->SetInitVector(m_DriverInfo->GetDriverCommon().m_InitAddress);
 				m_ExecutionHandler->SetStopVector(m_DriverInfo->GetDriverCommon().m_StopAddress);
 				m_ExecutionHandler->SetUpdateVector(m_DriverInfo->GetDriverCommon().m_UpdateAddress);
@@ -523,14 +525,13 @@ namespace Editor
 
 	bool EditorFacility::LoadAndConvertFile(const std::string& inPathAndFilename, ScreenBase* inCallerScreen, std::function<void()> inSuccesfullConversionAction)
 	{
-		const int max_file_size = 16 * 1024 * 1024;		// 16MB
+		const int max_file_size = 16 * 1024 * 1024; // 16MB
 
 		// Read test music data to cpu memory
 		void* data = nullptr;
 		long data_size = 0;
 
-		auto on_successfull_conversion = [this, inPathAndFilename, inCallerScreen, inSuccesfullConversionAction](std::shared_ptr<Utility::C64File> inC64File)
-		{
+		auto on_successfull_conversion = [this, inPathAndFilename, inCallerScreen, inSuccesfullConversionAction](std::shared_ptr<Utility::C64File> inC64File) {
 			std::shared_ptr<DriverInfo> driver_info = std::make_shared<DriverInfo>();
 
 			if (inC64File != nullptr)
@@ -548,7 +549,7 @@ namespace Editor
 					m_CPUMemory->SetData(inC64File->GetTopAddress(), inC64File->GetData(), inC64File->GetDataSize());
 					m_CPUMemory->Unlock();
 
-					// Init the execution handler 
+					// Init the execution handler
 					m_ExecutionHandler->SetInitVector(m_DriverInfo->GetDriverCommon().m_InitAddress);
 					m_ExecutionHandler->SetStopVector(m_DriverInfo->GetDriverCommon().m_StopAddress);
 					m_ExecutionHandler->SetUpdateVector(m_DriverInfo->GetDriverCommon().m_UpdateAddress);
@@ -662,8 +663,7 @@ namespace Editor
 	{
 		if (m_PackedData != nullptr)
 		{
-			auto do_save = [&, inFileName](std::string inTitle, std::string inAuthor, std::string inCopyright)
-			{
+			auto do_save = [&, inFileName](std::string inTitle, std::string inAuthor, std::string inCopyright) {
 				unsigned short top_of_file_address = m_PackedData->GetTopAddress();
 				unsigned short data_size = static_cast<unsigned short>(m_PackedData->GetDataSize());
 
@@ -818,7 +818,7 @@ namespace Editor
 				m_CPUMemory->SetData(inConversionResult->GetTopAddress(), inConversionResult->GetData(), inConversionResult->GetDataSize());
 				m_CPUMemory->Unlock();
 
-				// Init the execution handler 
+				// Init the execution handler
 				m_ExecutionHandler->SetInitVector(m_DriverInfo->GetDriverCommon().m_InitAddress);
 				m_ExecutionHandler->SetStopVector(m_DriverInfo->GetDriverCommon().m_StopAddress);
 				m_ExecutionHandler->SetUpdateVector(m_DriverInfo->GetDriverCommon().m_UpdateAddress);
@@ -854,12 +854,10 @@ namespace Editor
 		packing_info += "Size : 0x" + EditorUtils::ConvertToHexValue(static_cast<unsigned short>(m_PackedData->GetDataSize()), is_uppercase);
 
 		inCallerScreen->GetComponentsManager().StartDialog(
-			std::make_shared<DialogMessage>("Packing results", packing_info, 30, false, [&]() 
-			{
+			std::make_shared<DialogMessage>("Packing results", packing_info, 30, false, [&]() {
 				m_DiskScreen->SetMode(ScreenDisk::Mode::SavePacked);
 				SetCurrentScreen(m_DiskScreen.get());
-			})
-		);
+			}));
 	}
 
 
@@ -869,23 +867,21 @@ namespace Editor
 	}
 
 
-    void EditorFacility::OnSaveError(ScreenBase* inCallerScreen)
-    {
-        inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Error", "The file could not be saved to the current destination!", DefaultDialogWidth, true, []() {}));
-    }
+	void EditorFacility::OnSaveError(ScreenBase* inCallerScreen)
+	{
+		inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Error", "The file could not be saved to the current destination!", DefaultDialogWidth, true, []() {}));
+	}
 
 	//-------------------------------------------------------------------------------------------------------------------------
 
 
 	void EditorFacility::DoLoad(ScreenBase* inCallerScreen, const std::string& inSelectedFilename)
 	{
-		auto on_success = [this]()
-		{
+		auto on_success = [this]() {
 			RequestScreen(m_EditScreen.get());
 		};
 
-		auto do_load = [this, on_success, inSelectedFilename, inCallerScreen]()
-		{
+		auto do_load = [this, on_success, inSelectedFilename, inCallerScreen]() {
 			if (LoadFile(inSelectedFilename))
 				on_success();
 			else
@@ -910,19 +906,18 @@ namespace Editor
 
 		if (!exists(save_path_and_filename))
 		{
-			if(SaveFile(save_path_and_filename.string()))
-                RequestScreen(m_EditScreen.get());
-            else
-                OnSaveError(inCallerScreen);
+			if (SaveFile(save_path_and_filename.string()))
+				RequestScreen(m_EditScreen.get());
+			else
+				OnSaveError(inCallerScreen);
 		}
 		else if (IsFileSF2(save_path_and_filename.string()))
 		{
-			auto do_save = [save_path_and_filename, inCallerScreen, this]()
-			{
-				if(SaveFile(save_path_and_filename.string()))
-                    this->RequestScreen(this->m_EditScreen.get());
-                else
-                    OnSaveError(inCallerScreen);
+			auto do_save = [save_path_and_filename, inCallerScreen, this]() {
+				if (SaveFile(save_path_and_filename.string()))
+					this->RequestScreen(this->m_EditScreen.get());
+				else
+					OnSaveError(inCallerScreen);
 			};
 
 			inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessageYesNo>("Warning", inSelectedFilename + "\nAlready exists! Are you sure you want to overwrite it?", DefaultDialogWidth, do_save, []() {}));
@@ -959,13 +954,12 @@ namespace Editor
 		else if (!sf2_extension)
 			inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Illegal save destination", "You are trying to quick save to a file, with an extension other than .sf2.\nPlease save through the save disk menu!", DefaultDialogWidth, true, []() {}));
 		else
-		{	
-			auto do_save = [save_path_and_filename, inCallerScreen, this]()
-			{
-				if(SaveFile(save_path_and_filename.string()))
-                    this->m_EditScreen->SetStatusBarMessage(" Quick saved to: " + save_path_and_filename.filename().string(), 5000);
-                else
-                    this->OnSaveError(inCallerScreen);
+		{
+			auto do_save = [save_path_and_filename, inCallerScreen, this]() {
+				if (SaveFile(save_path_and_filename.string()))
+					this->m_EditScreen->SetStatusBarMessage(" Quick saved to: " + save_path_and_filename.filename().string(), 5000);
+				else
+					this->OnSaveError(inCallerScreen);
 			};
 
 			inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessageYesNo>("Warning", "Do you want to perform a quick save to:\n" + save_path_and_filename.string() + "?", DefaultDialogWidth, do_save, []() {}));
@@ -975,8 +969,7 @@ namespace Editor
 
 	void EditorFacility::DoImport(ScreenBase* inCallerScreen, const std::string& inSelectedFilename)
 	{
-		auto do_load = [&, inSelectedFilename, inCallerScreen]()
-		{
+		auto do_load = [&, inSelectedFilename, inCallerScreen]() {
 			std::shared_ptr<DriverInfo> import_driver_info = nullptr;
 			std::shared_ptr<Utility::C64File> import_c64_file = nullptr;
 
@@ -987,14 +980,13 @@ namespace Editor
 
 				if (!valid_music_data)
 					inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Import failure", "Unable to import music data!", DefaultDialogWidth, true, []() {}));
-				else if(!valid_tables)
+				else if (!valid_tables)
 					inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Import failure", "Unable to import table definitions!", DefaultDialogWidth, true, []() {}));
-				else 
+				else
 				{
 					ImportUtils::Import(inCallerScreen, *m_DriverInfo, *m_CPUMemory, *import_driver_info, *import_c64_file);
 					this->RequestScreen(this->m_EditScreen.get());
 				}
-
 			}
 			else
 				inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Invalid file", "The selected file is not compatible with SID Factory II import.", DefaultDialogWidth, true, []() {}));
@@ -1015,8 +1007,7 @@ namespace Editor
 		}
 		else
 		{
-			auto do_save = [save_path_and_filename, this]()
-			{
+			auto do_save = [save_path_and_filename, this]() {
 				SavePackedFile(save_path_and_filename.string());
 				this->RequestScreen(this->m_EditScreen.get());
 			};
@@ -1036,8 +1027,7 @@ namespace Editor
 		}
 		else
 		{
-			auto do_save = [inCallerScreen, save_path_and_filename, this]()
-			{
+			auto do_save = [inCallerScreen, save_path_and_filename, this]() {
 				SavePackedFileToSID(inCallerScreen, save_path_and_filename.string());
 			};
 
@@ -1068,15 +1058,18 @@ namespace Editor
 	}
 
 
-	std::string EditorFacility::ConfigureColorsFromScheme(int inSchemeIndex, const Utility::ConfigFile& inMainConfigFile, Foundation::Viewport& inViewport)
+	std::string EditorFacility::ConfigureColorsFromScheme(int inSchemeIndex, Foundation::Viewport& inViewport)
 	{
+		ConfigFile& configFile = Global::instance().GetConfig();
 		if (inSchemeIndex < m_ColorSchemeCount)
 		{
-			auto color_scheme_names = GetConfigurationValues<ConfigValueString>(inMainConfigFile, "ColorScheme.Name", {});
-			auto color_scheme_filenames = GetConfigurationValues<ConfigValueString>(inMainConfigFile, "ColorScheme.Filename", {});
 
-			std::string color_config_path_and_filename = m_Platform->Storage_GetColorSchemesHomePath() + color_scheme_filenames[inSchemeIndex];
-			ConfigFile color_config(*m_Platform, color_config_path_and_filename, inMainConfigFile.GetValidSectionTags());
+			IPlatform& platform = Global::instance().GetPlatform();
+			auto color_scheme_names = GetConfigurationValues<ConfigValueString>(configFile, "ColorScheme.Name", {});
+			auto color_scheme_filenames = GetConfigurationValues<ConfigValueString>(configFile, "ColorScheme.Filename", {});
+
+			std::string color_config_path_and_filename = platform.Storage_GetColorSchemesHomePath() + color_scheme_filenames[inSchemeIndex];
+			ConfigFile color_config(platform, color_config_path_and_filename, configFile.GetValidSectionTags());
 
 			if (color_config.IsValid())
 			{
@@ -1085,7 +1078,7 @@ namespace Editor
 			}
 		}
 
-		Utility::Config::ConfigureColors(inMainConfigFile, inViewport);
+		Utility::Config::ConfigureColors(configFile, inViewport);
 		return "Default";
 	}
 
@@ -1105,4 +1098,3 @@ namespace Editor
 	}
 
 }
-

--- a/SIDFactoryII/source/runtime/editor/editor_facility.cpp
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.cpp
@@ -98,7 +98,7 @@ namespace Editor
 		m_CPUMemory = new CPUMemory(0x10000, &platform);
 		m_CPU = new CPUmos6510();
 		m_FlightRecorder = new FlightRecorder(&platform, 0x800);
-		m_ExecutionHandler = new ExecutionHandler(&platform, m_CPU, m_CPUMemory, m_SIDProxy, m_FlightRecorder, configFile);
+		m_ExecutionHandler = new ExecutionHandler(m_CPU, m_CPUMemory, m_SIDProxy, m_FlightRecorder);
 
 		// Create audio stream
 		const int audio_buffer_size = GetSingleConfigurationValue<ConfigValueInt>(configFile, "Sound.Buffer.Size", 256);
@@ -112,7 +112,7 @@ namespace Editor
 		m_DriverInfo = std::make_shared<DriverInfo>();
 
 		// Create overlay control
-		m_OverlayControl = std::make_unique<OverlayControl>(configFile, inViewport, &platform);
+		m_OverlayControl = std::make_unique<OverlayControl>(inViewport);
 
 		// Create screens
 		m_IntroScreen = std::make_unique<ScreenIntro>(

--- a/SIDFactoryII/source/runtime/editor/editor_facility.h
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "runtime/editor/cursor_control.h"
-#include "runtime/editor/edit_state.h"
 #include "runtime/editor/display_state.h"
-#include "runtime/editor/overlay_control.h"
 #include "runtime/editor/driver/driver_info.h"
+#include "runtime/editor/edit_state.h"
 #include "runtime/editor/keys/keyhook_setup.h"
+#include "runtime/editor/overlay_control.h"
 #include "utils/keyhookstore.h"
+#include <functional>
 #include <memory>
 #include <string>
-#include <functional>
 
 namespace Foundation
 {
@@ -51,7 +51,7 @@ namespace Editor
 	public:
 		static const unsigned int DefaultDialogWidth;
 
-		EditorFacility(Foundation::IPlatform* platform, Foundation::Viewport* inViewport, Utility::ConfigFile& inConfigFile);
+		EditorFacility(Foundation::Viewport* inViewport);
 		~EditorFacility();
 
 		void Start(const char* inFileToLoad);
@@ -90,7 +90,7 @@ namespace Editor
 
 		void OnPack(ScreenBase* inCallerScreen, unsigned short inDestinationAddress);
 		void OnQuickSave(ScreenBase* inCallerScreen);
-        void OnSaveError(ScreenBase* inCallerScreen);
+		void OnSaveError(ScreenBase* inCallerScreen);
 
 		void DoLoad(ScreenBase* inCallerScreen, const std::string& inSelectedFilename);
 		void DoSave(ScreenBase* inCallerScreen, const std::string& inSelectedFilename);
@@ -102,7 +102,7 @@ namespace Editor
 		void DoSavePackedToSID(ScreenBase* inCallerScreen, const std::string& inSelectedFilename);
 
 		void SetLastSavedPathAndFilename(const std::string& inLastSavedPathAndFilename);
-		std::string ConfigureColorsFromScheme(int inSchemeIndex, const Utility::ConfigFile& inMainConfigFile, Foundation::Viewport& inViewport);
+		std::string ConfigureColorsFromScheme(int inSchemeIndex, Foundation::Viewport& inViewport);
 
 		std::vector<std::shared_ptr<ConverterBase>> GetConverters() const;
 
@@ -112,9 +112,6 @@ namespace Editor
 		int m_ColorSchemeCount;
 		int m_SelectedColorScheme;
 
-		Utility::ConfigFile& m_ConfigFile;
-
-		Foundation::IPlatform* m_Platform;
 		Foundation::Viewport* m_Viewport;
 		Foundation::TextField* m_TextField;
 		Foundation::AudioStream* m_AudioStream;
@@ -129,7 +126,7 @@ namespace Editor
 		DisplayState m_DisplayState;
 
 		CursorControl m_CursorControl;
-		
+
 		KeyHookSetup m_KeyHookSetup;
 
 		ScreenBase* m_RequestedScreen;

--- a/SIDFactoryII/source/runtime/editor/overlay_control.cpp
+++ b/SIDFactoryII/source/runtime/editor/overlay_control.cpp
@@ -6,6 +6,7 @@
 #include "libraries/picopng/picopng.h"
 #include "runtime/editor/driver/driver_info.h"
 #include "utils/configfile.h"
+#include "utils/global.h"
 #include "utils/utilities.h"
 #include <algorithm>
 
@@ -14,19 +15,24 @@ namespace Editor
 {
 	using namespace fs;
 	using namespace Utility;
+	using namespace Foundation;
 	using namespace Utility::Config;
 
-	OverlayControl::OverlayControl(const Utility::ConfigFile& inConfigFile, Foundation::Viewport* inViewport, const Foundation::IPlatform* inPlatform)
-		: m_Enabled(GetSingleConfigurationValue<ConfigValueInt>(inConfigFile, "Show.Overlay", 0) != 0)
-		, m_OverlayEnabledState(false)
+	OverlayControl::OverlayControl(Foundation::Viewport* inViewport)
+		: m_OverlayEnabledState(false)
 		, m_Viewport(inViewport)
 		, m_IsFading(true)
 		, m_FadeValue(0.0f)
 	{
-		ReadConfigValues(inConfigFile);
-		EnumeratePlatformFiles(inPlatform);
-		path overlays_path = inPlatform->Storage_GetOverlaysHomePath();
-		LoadOverlay(true, (overlays_path / (inPlatform->GetName() + "_editor.png")).string());
+		ConfigFile& configFile = Global::instance().GetConfig();
+		m_Enabled = GetSingleConfigurationValue<ConfigValueInt>(configFile, "Show.Overlay", 0) != 0;
+
+		IPlatform& platform = Global::instance().GetPlatform();
+
+		ReadConfigValues(configFile);
+		EnumeratePlatformFiles(platform);
+		path overlays_path = platform.Storage_GetOverlaysHomePath();
+		LoadOverlay(true, (overlays_path / (platform.GetName() + "_editor.png")).string());
 	}
 
 
@@ -149,10 +155,10 @@ namespace Editor
 	}
 
 
-	void OverlayControl::EnumeratePlatformFiles(const Foundation::IPlatform* inPlatform)
+	void OverlayControl::EnumeratePlatformFiles(const Foundation::IPlatform& inPlatform)
 	{
-		const std::string& platform_name = inPlatform->GetName();
-		directory_iterator directory_iterator(inPlatform->Storage_GetOverlaysHomePath());
+		const std::string& platform_name = inPlatform.GetName();
+		directory_iterator directory_iterator(inPlatform.Storage_GetOverlaysHomePath());
 
 		for (auto& path : directory_iterator)
 		{

--- a/SIDFactoryII/source/runtime/editor/overlay_control.h
+++ b/SIDFactoryII/source/runtime/editor/overlay_control.h
@@ -21,7 +21,7 @@ namespace Editor
 	class OverlayControl
 	{
 	public:
-		OverlayControl(const Utility::ConfigFile& inConfigFile, Foundation::Viewport* inViewport, const Foundation::IPlatform* inPlatform);
+		OverlayControl(Foundation::Viewport* inViewport);
 
 		void SetOverlayEnabled(bool inEnabled);
 		bool GetOverlayEnabled() const;
@@ -33,7 +33,7 @@ namespace Editor
 
 	private:
 		void ReadConfigValues(const Utility::ConfigFile& inConfigFile);
-		void EnumeratePlatformFiles(const Foundation::IPlatform* inPlatform);
+		void EnumeratePlatformFiles(const Foundation::IPlatform& inPlatform);
 		void LoadOverlay(bool inIsEditorOverlay, const std::string& inFilename);
 
 		bool m_Enabled;

--- a/SIDFactoryII/source/runtime/execution/executionhandler.cpp
+++ b/SIDFactoryII/source/runtime/execution/executionhandler.cpp
@@ -13,12 +13,14 @@
 
 #include "utils/configfile.h"
 #include "utils/logging.h"
+#include "utils/global.h"
 
 #include <algorithm>
 #include <iostream>
 
 
 using namespace Foundation;
+using namespace Utility;
 
 namespace Emulation
 {
@@ -28,12 +30,10 @@ namespace Emulation
 	const float sampleFloor = -32767.0f;
 
 	ExecutionHandler::ExecutionHandler(
-		IPlatform* inPlatform,
 		CPUmos6510* inCPU,
 		CPUMemory* pMemory,
 		SIDProxy* pSIDProxy,
-		FlightRecorder* inFlightRecorder,
-		Utility::ConfigFile& inConfigFile)
+		FlightRecorder* inFlightRecorder)
 		: m_CPU(inCPU)
 		, m_Memory(pMemory)
 		, m_SIDProxy(pSIDProxy)
@@ -51,10 +51,10 @@ namespace Emulation
 		// Create a sample buffer. The sample frequency is used for determining the size, which is probably 50 times the size required.
 		m_SampleBufferSize = (static_cast<unsigned int>(pSIDProxy->GetSampleFrequency()) << 8);
 		m_SampleBuffer = new short[m_SampleBufferSize];
-		m_Mutex = inPlatform->CreateMutex();
-		m_OutputGain = Utility::GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(inConfigFile, "Sound.Output.Gain", 1);
+		m_Mutex = Global::instance().GetPlatform().CreateMutex();
+		m_OutputGain = GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(Global::instance().GetConfig(), "Sound.Output.Gain", -1);
 
-		Utility::Logging::instance().Info("Sound.Output.Gain = %f", m_OutputGain);
+		Logging::instance().Info("Sound.Output.Gain = %f", m_OutputGain);
 
 		// Set default action vector
 		m_InitVector = 0x1000;

--- a/SIDFactoryII/source/runtime/execution/executionhandler.h
+++ b/SIDFactoryII/source/runtime/execution/executionhandler.h
@@ -29,12 +29,10 @@ namespace Emulation
 	{
 	public:
 		ExecutionHandler(
-			Foundation::IPlatform* pPlatformFactory,
 			CPUmos6510* pCPU,
 			CPUMemory* pMemory,
 			SIDProxy* pSIDProxy,
-			FlightRecorder* inFlightRecorder,
-			Utility::ConfigFile& inConfigFile);
+			FlightRecorder* inFlightRecorder);
 		~ExecutionHandler();
 
 		// IAudioStreamFeeder

--- a/SIDFactoryII/source/utils/configfile.h
+++ b/SIDFactoryII/source/utils/configfile.h
@@ -19,6 +19,10 @@ namespace Utility
 	public:
 		ConfigFile(const Foundation::IPlatform& inPlatform, const std::string& inFilename, const std::vector<std::string>& inValidSectionTags);
 
+		ConfigFile(ConfigFile& inOther) = delete;
+		ConfigFile(ConfigFile&& inOther) = delete;
+		ConfigFile(const ConfigFile& inOther) = delete;
+
 		bool IsValid() const;
 		const std::vector<std::string>& GetValidSectionTags() const;
 

--- a/SIDFactoryII/source/utils/global.cpp
+++ b/SIDFactoryII/source/utils/global.cpp
@@ -1,5 +1,9 @@
 #include "global.h"
+#include "configfile.h"
+#include "foundation/base/assert.h"
 #include "foundation/platform/platform_factory.h"
+#include <string>
+#include <vector>
 
 using namespace Foundation;
 
@@ -11,8 +15,38 @@ namespace Utility
 		static Global instance;
 		return instance;
 	}
+
+	// TODO: return const
+	IPlatform& Global::GetPlatform() const
+	{
+		FOUNDATION_ASSERT(m_Platform != nullptr);
+		return *m_Platform;
+	}
+	// TODO: return const
+	ConfigFile& Global::GetConfig() const
+	{
+		FOUNDATION_ASSERT(m_Config != nullptr);
+		return *m_Config;
+	}
+
 	Global::Global()
-		: m_Platform(Foundation::CreatePlatform()) {};
+		: m_Platform(Foundation::CreatePlatform())
+	{
+
+		// Read the config file
+		std::vector<std::string> valid_configuration_sections;
+		valid_configuration_sections.push_back("default");
+		valid_configuration_sections.push_back(m_Platform->GetName());
+#ifdef _DEBUG
+		valid_configuration_sections.push_back("debug");
+#endif //
+
+		std::string config_path = m_Platform->Storage_GetConfigHomePath();
+
+		ConfigFile configFile(*m_Platform, config_path + "config.ini", valid_configuration_sections);
+
+		m_Config = &configFile;
+	};
 
 	void Global::deletePlatform()
 	{

--- a/SIDFactoryII/source/utils/global.cpp
+++ b/SIDFactoryII/source/utils/global.cpp
@@ -1,0 +1,23 @@
+#include "global.h"
+#include "foundation/platform/platform_factory.h"
+
+using namespace Foundation;
+
+namespace Utility
+{
+
+	Global& Global::instance()
+	{
+		static Global instance;
+		return instance;
+	}
+	Global::Global()
+		: m_Platform(Foundation::CreatePlatform()) {};
+
+	void Global::deletePlatform()
+	{
+		delete m_Platform;
+		m_Platform = nullptr;
+	}
+
+}

--- a/SIDFactoryII/source/utils/global.cpp
+++ b/SIDFactoryII/source/utils/global.cpp
@@ -43,10 +43,16 @@ namespace Utility
 
 		std::string config_path = m_Platform->Storage_GetConfigHomePath();
 
-		ConfigFile configFile(*m_Platform, config_path + "config.ini", valid_configuration_sections);
-
-		m_Config = &configFile;
+		m_Config = new ConfigFile(*m_Platform, config_path + "config.ini", valid_configuration_sections);
 	};
+
+	Global::~Global()
+	{
+		delete m_Platform;
+		m_Platform = nullptr;
+		delete m_Config;
+		m_Config = nullptr;
+	}
 
 	void Global::deletePlatform()
 	{

--- a/SIDFactoryII/source/utils/global.h
+++ b/SIDFactoryII/source/utils/global.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace Foundation
+{
+	class IPlatform;
+}
+
+namespace Utility
+{
+	// Singleton for global configuration
+	class Global
+	{
+
+	public:
+		static Global& instance();
+		Foundation::IPlatform* m_Platform;
+		void deletePlatform();
+
+	private:
+		Global();
+	};
+
+}

--- a/SIDFactoryII/source/utils/global.h
+++ b/SIDFactoryII/source/utils/global.h
@@ -1,8 +1,12 @@
 #pragma once
-
 namespace Foundation
 {
 	class IPlatform;
+}
+
+namespace Utility
+{
+	class ConfigFile;
 }
 
 namespace Utility
@@ -13,11 +17,14 @@ namespace Utility
 
 	public:
 		static Global& instance();
-		Foundation::IPlatform* m_Platform;
 		void deletePlatform();
+		Foundation::IPlatform& GetPlatform() const;
+		Utility::ConfigFile& GetConfig() const;
 
 	private:
 		Global();
+		Foundation::IPlatform* m_Platform;
+		Utility::ConfigFile* m_Config;
 	};
 
 }

--- a/SIDFactoryII/source/utils/global.h
+++ b/SIDFactoryII/source/utils/global.h
@@ -17,12 +17,18 @@ namespace Utility
 
 	public:
 		static Global& instance();
+		Global(Global& inOther) = delete;
+		Global(Global&& inOther) = delete;
+		Global(const Global& inOther) = delete;
+
+		// TODO: is this needed?
 		void deletePlatform();
 		Foundation::IPlatform& GetPlatform() const;
 		Utility::ConfigFile& GetConfig() const;
 
 	private:
 		Global();
+		~Global();
 		Foundation::IPlatform* m_Platform;
 		Utility::ConfigFile* m_Config;
 	};


### PR DESCRIPTION
Idea: a singleton with access to global config. On construction, it creates a property for the "config.ini" configfile which can be accessed anywhere without injecting the configfile object in every class we need it.
Because the configfile class is dependent on IPlatform, the creation of the platform object is also done in the global singleton.
Later we could move the utility methods for accessing "config.ini" here aswell.