### PR TITLE
Configure quick save confirmation on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20windows%20bi
 binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20binaries/badge.svg)
 ![Build linux binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20linux%20binaries/badge.svg)
 
-![SID Factory II screenshot](https://chordian.net/media/SF2_20200816.png 'SID Factory II')
+![SID Factory II screenshot](https://chordian.net/media/SF2_20200816.png "SID Factory II")
 
 ## Changelog
 
@@ -20,7 +20,10 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
   Including a default template.
 - Added: configuration option `Window.Scaling` to scale the contents of the
   window. (Thanks to Matty Seito for suggesting)
-- Added: Configuration option `Sound.Output.Gain` for boosting/lowering output volume of the editor.
+- Added: Configuration options:
+  - `Editor.Confirm.QuickSave` to enable/disable confirmation dialog on quick
+    save.
+  - `Sound.Output.Gain` for boosting/lowering output volume of the editor.
 - Added: Configuration options (thanks to Laszlo Vincenzo Vincze for suggesting):
   - `Editor.Follow.Play` to set default follow play on/off.
   - `Editor.Sequence.Highlights` to set default

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -44,6 +44,9 @@ Editor.Follow.Play                  = 0         // If you set this to 1, follow 
 
 Editor.Sequence.Highlights          = 0         // If you set this to 1, sequence highlights are on by default. 
 
+Editor.Confirm.QuickSave            = 1         // If you set this to 1, a confirmation dialog pops up when quick saving
+                                                // If set to 0, the quick save is performed without asking for confirmation
+
 Editor.Driver.ConvertLegacyColors   = 1         // DEPRECATED - this will be deleted soon.
 
 //

--- a/SIDFactoryII/source/runtime/editor/editor_facility.cpp
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.cpp
@@ -966,6 +966,8 @@ namespace Editor
 			inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessage>("Illegal save destination", "You are trying to quick save to a file, with an extension other than .sf2.\nPlease save through the save disk menu!", DefaultDialogWidth, true, []() {}));
 		else
 		{
+			const bool confirm_quick_save = GetSingleConfigurationValue<ConfigValueInt>(Global::instance().GetConfig(), "Editor.Confirm.QuickSave", 1) != 0;
+			
 			auto do_save = [save_path_and_filename, inCallerScreen, this]() {
 				if (SaveFile(save_path_and_filename.string()))
 					this->m_EditScreen->SetStatusBarMessage(" Quick saved to: " + save_path_and_filename.filename().string(), 5000);
@@ -973,8 +975,15 @@ namespace Editor
 					this->OnSaveError(inCallerScreen);
 			};
 
-			inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessageYesNo>("Warning", "Do you want to perform a quick save to:\n" + save_path_and_filename.string() + "?", DefaultDialogWidth, do_save, []() {}));
+			if (confirm_quick_save) {
+				inCallerScreen->GetComponentsManager().StartDialog(std::make_shared<DialogMessageYesNo>("Warning", "Do you want to perform a quick save to:\n" + save_path_and_filename.string() + "?", DefaultDialogWidth, do_save, []() {}));
+			}
+			else {
+				do_save();
+			}
+		
 		}
+
 	}
 
 

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -32,6 +32,10 @@ Editor.Follow.Play                  = 0         // If you set this to 1, follow 
 
 Editor.Sequence.Highlights          = 0         // If you set this to 1, sequence highlights are on by default.
 
+Editor.Confirm.QuickSave            = 1         // If you set this to 1, a confirmation dialog pops up when quick saving
+                                                // If set to 0, the quick save is performed without asking for confirmation
+
+
 //
 // WINDOW
 //


### PR DESCRIPTION
Configuration option to enable/disable the confirmation dialog when you quick save.

Resolves #16 