### PR TITLE
Added include to picopng.h so SF2 compiles on Arch linux

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,13 @@ To build:
 
 Then look in the `artifacts` folder.
 
+## External dependencies
+
+### PicoPNG
+
+PicoPNG files were copied from https://lodev.org/lodepng
+A small change was made to `picopng.h` in relation to [issue 134](https://github.com/Chordian/sidfactory2/issues/134)
+
 ## Releases and nightly builds
 
 There are two sets of binaries:

--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,26 @@ clean:
 	rm ${OBJ} || true
 	rm -rf $(ARTIFACTS_FOLDER) || true
 
-# Compile with the Ubuntu image on Docker
-BUILD_IMAGE_UBUNTU=sidfactory2/build-ubuntu
+# --- DOCKER BUILDS ---
+
 TMP_CONTAINER=sf2_build_tmp
+
+# Compile with the Ubuntu image
+BUILD_IMAGE_UBUNTU=sidfactory2/build-ubuntu
 
 ubuntu:
 	docker container rm $(TMP_CONTAINER) || true
 	docker build -t $(BUILD_IMAGE_UBUNTU) .
 	docker run --name $(TMP_CONTAINER) $(BUILD_IMAGE_UBUNTU)
+	docker cp $(TMP_CONTAINER):/home/$(ARTIFACTS_FOLDER) .
+	docker container rm $(TMP_CONTAINER)
+
+# Compile with the Archlinux image
+BUILD_IMAGE_ARCHLINUX=sidfactory2/build-archlinux
+
+archlinux:
+	docker container rm $(TMP_CONTAINER) || true
+	docker build -t $(BUILD_IMAGE_ARCHLINUX) -f Dockerfile.Archlinux .
+	docker run --name $(TMP_CONTAINER) $(BUILD_IMAGE_ARCHLINUX)
 	docker cp $(TMP_CONTAINER):/home/$(ARTIFACTS_FOLDER) .
 	docker container rm $(TMP_CONTAINER)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
 - Fixed: [#133](https://github.com/Chordian/sidfactory2/issues/133) Emulation
   error when starting up linux version. (Thanks to Maurizio Dall'Acqua for
   reporting)
+- Fixed: [#134](https://github.com/Chordian/sidfactory2/issues/134) SF2 won't
+  compile on Arch Linux (Thanks to jansalleine for reporting amd suggesting the
+  fix)
 
 ### Build 20210104
 

--- a/SIDFactoryII/source/libraries/picopng/picopng.h
+++ b/SIDFactoryII/source/libraries/picopng/picopng.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <cstddef>
 
 namespace PicoPNG
 {


### PR DESCRIPTION
Fixes #134

Because picopng is poorly maintained we cannot expect a fix from them. The impact is small as we do not expect to be needing an upgrade for picopng, and picopng is not a big risk for SF2 as it is only used for the title screen.