### PR TITLE
Configuration parameters for filter curve. #144

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20windows%20bi
 binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20binaries/badge.svg)
 ![Build linux binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20linux%20binaries/badge.svg)
 
-![SID Factory II screenshot](https://chordian.net/media/SF2_20200816.png "SID Factory II")
+![SID Factory II screenshot](https://chordian.net/media/SF2_20200816.png 'SID Factory II')
 
 ## Changelog
 
+- Added: Documentation on how to customize configuration using a `user.ini`
+  file. Including a default template `/documentation/user.default.ini`.
+- Added: [#144](https://github.com/Chordian/sidfactory2/issues/144)
+  Configuration options:
+  - `Sound.Emulation.8580.FilterCurve` for adjusting the filter of the 8580 model.
+  - `Sound.Emulation.6581.FilterCurve` for adjusting the filter of the 6581 model.
 - Added: An option in the packer to specify the base for zero page addresses
   that the player uses.
 - Changed: [#142](https://github.com/Chordian/sidfactory2/issues/142) the
   list of keys that can be remapped is complete now. Please note: the names for
   keycodes starting with `num` are renamed to start with `kp_`.
-- Added: Documentation on how to customize configuration using a `user.ini`
-  file. Including a default template `/documentation/user.default.ini`.
 - Added: Configuration option `Window.Scaling` to scale the contents of the
   window. (Thanks to Matty Seito for suggesting)
 - Added: Configuration options (thanks to Laszlo Vincenzo Vincze for

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -23,6 +23,11 @@ Sound.Emulation.Default.Model       = 8580      // Default SID model to start wi
 
 Sound.Emulation.Default.Region      = "PAL"     // Default region to start with on empty song. "PAL" or "NTSC"
 
+Sound.Emulation.8580.FilterCurve    = 0.5      // Set filter curve type for 8580 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+Sound.Emulation.6581.FilterCurve    = 0.5      // Set filter curve type for 6581 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear.
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 

--- a/SIDFactoryII/config/config.ini
+++ b/SIDFactoryII/config/config.ini
@@ -23,6 +23,11 @@ Sound.Emulation.Default.Model       = 8580      // Default SID model to start wi
 
 Sound.Emulation.Default.Region      = "PAL"     // Default region to start with on empty song. "PAL" or "NTSC"
 
+Sound.Emulation.8580.FilterCurve    = 0.5      // Set filter curve type for 8580 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+Sound.Emulation.6581.FilterCurve    = 0.5      // Set filter curve type for 6581 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear.
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 

--- a/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
+++ b/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
@@ -4,7 +4,14 @@
 #include "libraries/residfp/SID.h"
 
 #include "foundation/base/assert.h"
+
+#include "utils/configfile.h"
+#include "utils/global.h"
+#include "utils/logging.h"
+
 #include <cmath>
+
+using namespace Utility;
 
 namespace Emulation
 {
@@ -102,15 +109,48 @@ namespace Emulation
 
 			const double passband = 20000.0;
 
-			m_pSID->setSamplingParameters
-			(
+			double filter_8580_curve = GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(Global::instance().GetConfig(), "Sound.Emulation.8580.FilterCurve", 0.5);
+			if (filter_8580_curve < 0.0)
+			{
+				Logging::instance().Warning("Sound.Emulation.8580.FilterCurve %f is lower than 0. Limiting to 0", filter_8580_curve);
+				filter_8580_curve = 0.0;
+			}
+			if (filter_8580_curve > 1.0)
+			{
+				Logging::instance().Warning("Sound.Emulation.8580.FilterCurve %f is higher than 1.0. Limiting to 1.0", filter_8580_curve);
+				filter_8580_curve = 1.0;
+			}
+
+			double filter_6581_curve = GetSingleConfigurationValue<Utility::Config::ConfigValueFloat>(Global::instance().GetConfig(), "Sound.Emulation.6581.FilterCurve", 0.5);
+			if (filter_6581_curve < 0.0)
+			{
+				Logging::instance().Warning("Sound.Emulation.6581.FilterCurve %f is lower than 0.0 Limiting to 0.0", filter_6581_curve);
+				filter_6581_curve = 0.0;
+			}
+			if (filter_6581_curve > 1.0)
+			{
+				Logging::instance().Warning("Sound.Emulation.6581.FilterCurve %f is higher than 1.0. Limiting to 1.0", filter_6581_curve);
+				filter_6581_curve = 1.0;
+			}
+
+			m_pSID->setSamplingParameters(
 				static_cast<double>(m_sConfiguration.m_eEnvironment == SID_ENVIRONMENT_PAL ? EMULATION_CYCLES_PER_SECOND_PAL : EMULATION_CYCLES_PER_SECOND_NTSC),
 				m_sConfiguration.m_eSampleMethod != SID_SAMPLE_METHOD_RESAMPLE_INTERPOLATE ? SamplingMethod::DECIMATE : SamplingMethod::RESAMPLE,
 				static_cast<double>(m_sConfiguration.m_nSampleFrequency),
-				passband
-			);
+				passband);
 
 			m_pSID->setChipModel(m_sConfiguration.m_eModel == SID_MODEL_6581 ? ChipModel::MOS6581 : ChipModel::MOS8580);
+			m_pSID->setFilter8580Curve(filter_8580_curve);
+			m_pSID->setFilter6581Curve(filter_6581_curve);
+
+			if (m_sConfiguration.m_eModel == SID_MODEL_6581)
+			{
+				Logging::instance().Info("Sound.Emulation.6581.FilterCurve set to %f", filter_6581_curve);
+			}
+			else
+			{
+				Logging::instance().Info("Sound.Emulation.8580.FilterCurve set to %f", filter_8580_curve);
+			}
 		}
 	}
 
@@ -193,11 +233,19 @@ namespace Emulation
 //		{
 //			float r = (static_cast<float>(m_SampleCounter) * 2.0f * 3.1416f) / 25.0f;
 //			short v = static_cast<short>(std::sinf(r) * 65535.0f / 4.0f);
+		//
 //		
-//			pBuffer[i] = v;
+		//
 //		
-//			m_SampleCounter++;
-//		}
+		//
+//		
+		//
+		//			pBuffer[i] = v;
+		//
+//		
+		//
+		//			m_SampleCounter++;
+		//		}
 
 		if (IsRecordingToFile())
 		{

--- a/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
+++ b/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
@@ -143,14 +143,8 @@ namespace Emulation
 			m_pSID->setFilter8580Curve(filter_8580_curve);
 			m_pSID->setFilter6581Curve(filter_6581_curve);
 
-			if (m_sConfiguration.m_eModel == SID_MODEL_6581)
-			{
-				Logging::instance().Info("Sound.Emulation.6581.FilterCurve set to %f", filter_6581_curve);
-			}
-			else
-			{
-				Logging::instance().Info("Sound.Emulation.8580.FilterCurve set to %f", filter_8580_curve);
-			}
+			Logging::instance().Info("Sound.Emulation.6581.FilterCurve set to %f", filter_6581_curve);
+			Logging::instance().Info("Sound.Emulation.8580.FilterCurve set to %f", filter_8580_curve);
 		}
 	}
 
@@ -234,15 +228,17 @@ namespace Emulation
 //			float r = (static_cast<float>(m_SampleCounter) * 2.0f * 3.1416f) / 25.0f;
 //			short v = static_cast<short>(std::sinf(r) * 65535.0f / 4.0f);
 		//
-//		
+//
 		//
-//		
+//
 		//
-//		
+//
 		//
-		//			pBuffer[i] = v;
+//
 		//
-//		
+//			pBuffer[i] = v;
+		//
+//
 		//
 		//			m_SampleCounter++;
 		//		}

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -16,6 +16,11 @@ Sound.Emulation.Default.Model       = 8580      // Default SID model to start wi
 
 Sound.Emulation.Default.Region      = "PAL"     // Default region to start with on empty song. "PAL" or "NTSC"
 
+Sound.Emulation.8580.FilterCurve    = 0.5      // Set filter curve type for 8580 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+Sound.Emulation.6581.FilterCurve    = 0.5      // Set filter curve type for 6581 model based on single parameter.
+                                               // Accepts values from 0.0 (bright) to 1.0 (dark)
+
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 


### PR DESCRIPTION
The ReSID engine allows setting a filter curve with one parameter.
Added config options that allow setting this curve to taste.