### PR TITLE
Build a universal App on macOS #146

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
 
 ## Changelog
 
+- Changed: [#146](https://github.com/Chordian/sidfactory2/issues/146) the
+  official macOS distribution is now a universal application, meaning it will
+  run native both on the new M1 (arm_64) and the Intel (x86_64) architecture.
+  The architecture the application is running on is reflected in the build
+  number in the lower right corner of the startup screen.
 - Added: Documentation on how to customize configuration using a `user.ini`
   file. Including a default template `/documentation/user.default.ini`.
 - Added: [#144](https://github.com/Chordian/sidfactory2/issues/144)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
 
 - Changed: [#146](https://github.com/Chordian/sidfactory2/issues/146) the
   official macOS distribution is now a universal application, meaning it will
-  run native both on the new M1 (arm_64) and the Intel (x86_64) architecture.
+  run native both on the new M1 (arm64) and the Intel (x86_64) architecture.
   The architecture the application is running on is reflected in the build
   number in the lower right corner of the startup screen.
 - Added: Documentation on how to customize configuration using a `user.ini`

--- a/SIDFactoryII/source/runtime/editor/screens/screen_intro.cpp
+++ b/SIDFactoryII/source/runtime/editor/screens/screen_intro.cpp
@@ -43,7 +43,7 @@ namespace Editor
 		const std::string build_number = std::string(__DATE__);
 #endif
 
-		const std::string build_string = "Development build: " + build_number + " ";
+		const std::string build_string = "Build " + build_number + " ";
 
 		// Load bmp
 		void* file_buffer;

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -1,7 +1,11 @@
 # Makefile for macOS version
 
+TARGET=x86_64-apple-macos10.09
+
+BUILD_NR=$(shell git show --no-patch --format='%cs').$(shell git rev-parse --short HEAD)
+BUILD_NR_TARGET=$(BUILD_NR).$(TARGET)
+
 # Sources
-BUILD_NR= $(shell git show --no-patch --format='%cs').$(shell git rev-parse --short HEAD)
 PROJECT_ROOT=../SIDFactoryII
 SOURCE=$(PROJECT_ROOT)/source
 SRC_TMP=$(PROJECT_ROOT)/main.cpp $(shell find $(SOURCE) -name "*.cpp")
@@ -21,17 +25,18 @@ DMG_SIZE=25600
 ICONSET=$(ARTIFACTS_FOLDER)/$(APP_NAME).iconset
 ICONS=$(ARTIFACTS_FOLDER)/$(APP_NAME).icns
 
-CC=MACOSX_DEPLOYMENT_TARGET=10.9 g++
+CC=g++
 
 CC_FLAGS= \
   -I$(SOURCE) \
 	-I./App/Contents/Frameworks/SDL2.framework/Headers \
-	-D_BUILD_NR=\"$(BUILD_NR)\" \
+	-D_BUILD_NR=\"$(BUILD_NR_TARGET)\" \
 	-std=gnu++14 \
 	-stdlib=libc++ \
 	-O2 \
 	-DNDEBUG \
-	-flto
+	-flto \
+	-target $(TARGET)
 
 LINKER_FLAGS=\
 	-framework SDL2 \
@@ -39,7 +44,8 @@ LINKER_FLAGS=\
 	-F./App/Contents/Frameworks \
 	-lstdc++ \
 	-flto \
-	-Wl,-rpath,@executable_path/../Frameworks
+	-Wl,-rpath,@executable_path/../Frameworks \
+	-target $(TARGET)
 
 .PHONY: clean
 .PHONY: tmp
@@ -52,7 +58,7 @@ LINKER_FLAGS=\
 
 # Rule to compile .o from .c
 %.o: %.c
-	$(CC) -c $< -o $@
+	$(CC) -target $(TARGET) -c $< -o $@
 
 # Determine all .o files to be built
 OBJ = $(SRC:.cpp=.o) $(SOURCE)/libraries/miniz/miniz.o
@@ -61,6 +67,15 @@ OBJ = $(SRC:.cpp=.o) $(SOURCE)/libraries/miniz/miniz.o
 $(EXE): $(OBJ) $(ARTIFACTS_FOLDER)
 	$(CC) $(LINKER_FLAGS) -o $(EXE) $(OBJ)
 	strip $(EXE)
+
+# Make universal binary
+universal: | clean $(EXE)
+	rm ${OBJ} || true
+	mv $(EXE) $(EXE)_x86
+	make TARGET=arm64-apple-macos11
+	mv $(EXE) $(EXE)_arm
+	lipo -create -output $(EXE) $(EXE)_x86 $(EXE)_arm
+	rm $(EXE)_x86 $(EXE)_arm
 
 app: $(APP)
 
@@ -77,7 +92,7 @@ dmg: $(DMG)
 # ---------------------------------------------------
 
 # Package executable and dependencies in macOS App
-$(APP): $(EXE) $(ICONS)
+$(APP): universal $(ICONS)
 	rm -rf $(APP)
 	mkdir -p $(APP)
 	cp -r App/ ${APP}


### PR DESCRIPTION
The official macOS distribution is now a universal application, meaning it will
run native both on the new M1 (arm_64) and the Intel (x86_64) architecture.

The architecture the application is running on is reflected in the build
number in the lower right corner of the startup screen.

I changed the "Development build" in the startup screen to "Build" to make space for the extra architecture identifier.

Fixes #146 