### PR TITLE
Add sample rate config option / fix reSID reset click

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Please report issues in our [issue tracker](https://github.com/issues).
 
 ## Changelog
 
+- Added: An option to set the emulation sample rate to a user defined value 
+  (Thanks to Tammo Hinrichs)
+- Fixed: reSID won't output a click anymore when launching SID Factory II or
+  loading/saving files (Thanks to Tammo Hinrichs)
+
 ### Build 20211230
 
 - Added: You can now add labels for song list rows. Left-click to edit a label.

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -33,6 +33,8 @@ Sound.Emulation.Resample            = 1         // If this is set to 1, the SID 
 
 Sound.Output.Gain                   = 1.0       // Boost/lower volume. Sound can become distorted for value higher than 1.0.
 
+Sound.Emulation.SampleFrequency		= 44100     // Output sample frequency in Hz (22050/44100/48000/96000 etc.)
+
 Sound.Buffer.Size                   = 256       // This should always be a power of two. The smallest size possible is 128. If you experience a
                                                 // stuttering sound when playing back sound in the editor, try increasing this.
 
@@ -212,6 +214,8 @@ Key.OrderListOverview.Copy                          = @c:control
 Key.OrderListOverview.Paste                         = @v:control
 
 [windows]   // Applies to the windows platform only
+
+Sound.Emulation.SampleFrequency	= 48000
 
 // Disk.Startup.Folder = ""   // Uncomment and enter the absolute path to the folder that should
                               // open by default in the file browser.

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -33,7 +33,7 @@ Sound.Emulation.Resample            = 1         // If this is set to 1, the SID 
 
 Sound.Output.Gain                   = 1.0       // Boost/lower volume. Sound can become distorted for value higher than 1.0.
 
-Sound.Emulation.SampleFrequency		= 44100     // Output sample frequency in Hz (22050/44100/48000/96000 etc.)
+Sound.Emulation.SampleFrequency		= 44100     // Output sample frequency in Hz from 11025 to 192000
 
 Sound.Buffer.Size                   = 256       // This should always be a power of two. The smallest size possible is 128. If you experience a
                                                 // stuttering sound when playing back sound in the editor, try increasing this.

--- a/SIDFactoryII/source/libraries/residfp/ExternalFilter.cpp
+++ b/SIDFactoryII/source/libraries/residfp/ExternalFilter.cpp
@@ -42,7 +42,8 @@ ExternalFilter::ExternalFilter() :
     Vlp(0),
     Vhp(0),
     w0lp_1_s7(0),
-    w0hp_1_s17(0)
+    w0hp_1_s17(0), 
+    reset_pipeline(0)
 {
     reset();
 }
@@ -61,6 +62,7 @@ void ExternalFilter::reset()
     // State of filter.
     Vlp = 0; //1 << (15 + 11);
     Vhp = 0;
+		reset_pipeline = 1;
 }
 
 } // namespace reSIDfp

--- a/SIDFactoryII/source/libraries/residfp/ExternalFilter.h
+++ b/SIDFactoryII/source/libraries/residfp/ExternalFilter.h
@@ -58,6 +58,9 @@ private:
 
     int w0hp_1_s17;
 
+    /// used to prime the filters after a reset
+    unsigned int reset_pipeline;
+
 public:
     /**
      * SID clocking.
@@ -95,6 +98,14 @@ RESID_INLINE
 int ExternalFilter::clock(unsigned short input)
 {
     const int Vi = (static_cast<unsigned int>(input)<<11) - (1 << (11+15));
+
+    if (reset_pipeline)
+		{
+			Vlp = Vi;
+			Vhp = Vi;
+			reset_pipeline = 0;
+    }
+
     const int dVlp = (w0lp_1_s7 * (Vi - Vlp) >> 7);
     const int dVhp = (w0hp_1_s17 * (Vlp - Vhp) >> 17);
     Vlp += dVlp;

--- a/SIDFactoryII/source/runtime/editor/editor_facility.cpp
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.cpp
@@ -100,7 +100,22 @@ namespace Editor
 		SIDConfiguration sid_configuration; // Default settings are applicable
 
 		const bool sid_use_resample = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Emulation.Resample", 1) != 0;
-		const int sid_sample_frequency = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Emulation.SampleFrequency", 44100);
+		
+		int sid_sample_frequency = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Emulation.SampleFrequency", 44100);
+		if (sid_sample_frequency < 11025)
+		{
+			// In resampling mode reSID can downsample down to clock/125 Hz. With NTSC this puts us at min. 8200Hz,
+			// so let's use 11025 which is the next higher usual rate. 
+			Logging::instance().Warning("Sound.Emulation.SampleFrequency (%d) is too low, using 11025 instead", sid_sample_frequency);
+			sid_sample_frequency = 11025;
+		}
+		else if (sid_sample_frequency > 192000)
+		{
+			Logging::instance().Warning("Sound.Emulation.SampleFrequency (%d) is too high, using 192000 instead", sid_sample_frequency);
+			sid_sample_frequency = 192000;
+		}
+		Logging::instance().Info("Sound.Emulation.SampleFrequency set to %d", sid_sample_frequency);
+
 		sid_configuration.m_eSampleMethod = sid_use_resample ? SID_SAMPLE_METHOD_RESAMPLE_INTERPOLATE : SID_SAMPLE_METHOD_INTERPOLATE;
 		sid_configuration.m_eModel = SID_MODEL_6581;
 		sid_configuration.m_nSampleFrequency = sid_sample_frequency;

--- a/SIDFactoryII/source/runtime/editor/editor_facility.cpp
+++ b/SIDFactoryII/source/runtime/editor/editor_facility.cpp
@@ -100,9 +100,10 @@ namespace Editor
 		SIDConfiguration sid_configuration; // Default settings are applicable
 
 		const bool sid_use_resample = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Emulation.Resample", 1) != 0;
+		const int sid_sample_frequency = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Emulation.SampleFrequency", 44100);
 		sid_configuration.m_eSampleMethod = sid_use_resample ? SID_SAMPLE_METHOD_RESAMPLE_INTERPOLATE : SID_SAMPLE_METHOD_INTERPOLATE;
 		sid_configuration.m_eModel = SID_MODEL_6581;
-
+		sid_configuration.m_nSampleFrequency = sid_sample_frequency;
 
 		m_SIDProxy = new SIDProxy(sid_configuration);
 		m_CPUMemory = new CPUMemory(0x10000, &platform);
@@ -112,7 +113,7 @@ namespace Editor
 
 		// Create audio stream
 		const int audio_buffer_size = GetSingleConfigurationValue<ConfigValueInt>(config, "Sound.Buffer.Size", 256);
-		m_AudioStream = new AudioStream(44100, 16, std::max<const int>(audio_buffer_size, 0x80), m_ExecutionHandler);
+		m_AudioStream = new AudioStream(sid_sample_frequency, 16, std::max<const int>(audio_buffer_size, 0x80), m_ExecutionHandler);
 
 		// Create the main text field
 		m_TextField = m_Viewport->CreateTextField(m_Viewport->GetClientWidth() / TextField::font_width, m_Viewport->GetClientHeight() / TextField::font_height, 0, 0);

--- a/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
+++ b/SIDFactoryII/source/runtime/emulation/sid/sidproxy.cpp
@@ -163,7 +163,7 @@ namespace Emulation
 		if (m_FileOutput.size() > 0)
 		{
 			FILE* file = fopen(m_FileName.c_str(), "wb");
-
+		
 			struct wave_header
 			{
 				char chunk_id[4] = { 'R', 'I', 'F', 'F' };
@@ -185,6 +185,9 @@ namespace Emulation
 			header.chunk_size = 36 + data_size;
 			header.sub_chunk1_size = 16;
 			header.sub_chunk2_size = data_size;
+
+			header.sample_rate = m_sConfiguration.m_nSampleFrequency;
+			header.byte_rate = header.block_align * m_sConfiguration.m_nSampleFrequency;
 
 			fwrite(&header, sizeof(wave_header), 1, file);
 

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -24,6 +24,8 @@ Sound.Emulation.6581.FilterCurve    = 0.5      // Set filter curve type for 6581
 Sound.Emulation.Resample            = 1         // If this is set to 1, the SID emulation will use resampling, otherwise it will only use linear
                                                 // interpolation. Resampling is the best quality possible but also requires more CPU power.
 
+Sound.Emulation.SampleFrequency		= 44100     // Output sample frequency in Hz from 11025 to 192000
+
 Sound.Buffer.Size                   = 256       // This should always be a power of two. The smallest size possible is 128. If you experience a
 
                                                 // stuttering sound when playing back sound in the editor, try increasing this.
@@ -60,6 +62,8 @@ Show.Overlay                        = 0         // If you set this to 1, the ove
                                                 // Note that you can always toggle the overlay on and off with the F12 hotkey.
 
 [windows]   // Applies to the windows platform only
+
+Sound.Emulation.SampleFrequency	= 48000
 
 // Disk.Startup.Folder = ""   // Uncomment and enter the absolute path to the folder that should
                               // open by default in the file browser.


### PR DESCRIPTION
This PR does two things:

1. make the emulation sample rate configurable. I realized that on my laptop under Windows there were clearly audible 44100->48000 resampling artifacts so I added a Sound.Emulation.SampleFrequency config option (valid for both sound output and disk writing). I set the default for Windows to 48000 because that's the rate the Windows audio system works on the absolute majority of devices nowadays.

2. get rid of the clicks each time reSID is reset. This probably warrants an explanation: The SID has quite a DC offset on its output pin so on the C64's board there's a high pass filter at around 16Hz that eliminates that offset. All of this is faithfully emulated by reSID in ExternalFilter.cpp/h - albeit perhaps a bit too faithfully. When you turn on the C64 the filter's capacitors need to charge up first, resulting in a loud click, and reSID does the same thing on each reset. My change primes the filter state to that DC offset on the first sample after a reset, i.e. "pre-charges the capacitors", so to speak. I reckon less annoyance especially when using headphones is more important here than being physically correct on that specific detail :)

