### PR TITLE
Fixed not being able to change sequences at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ binaries](https://github.com/Chordian/sidfactory2/workflows/Build%20macOS%20bina
 
 Please report issues in our [issue tracker](https://github.com/issues).
 
+### Next release
+
 ![Commits since last release](https://img.shields.io/github/commits-since/chordian/sidfactory2/release-20220914)
+
+- Fixed: A bug where sometimes you couldn't edit sequences before hitting the
+  play button.
 
 ### Build 20220914
 

--- a/SIDFactoryII/source/runtime/editor/edit_state.cpp
+++ b/SIDFactoryII/source/runtime/editor/edit_state.cpp
@@ -9,6 +9,7 @@ namespace Editor
 		, m_SequenceHighlightingEnabled(false)
 		, m_EventHighlight( { 0, 4 })
 		, m_FollowPlayMode(false)
+		, m_PreventSequenceEdit(false)
 	{
 	}
 


### PR DESCRIPTION
Reproduce:

- Open SF2 and press space to get beyong opening screen
- Try to edit a sequence -> Nothing happens, cursor is not going anywhere
- Play and stop tune
- Now you can edit

This sometimes occurs. 