### PR TITLE
Switch for ASID/RESID output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@
 Language:        Cpp
 # BasedOnStyle:  WebKit
 IndentAccessModifiers: false
-AccessModifierOffset: -2
+AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false

--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@
   # https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 Language:        Cpp
 # BasedOnStyle:  WebKit
+IndentAccessModifiers: false
 AccessModifierOffset: -2
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveMacros: false
@@ -36,7 +37,7 @@ BraceWrapping:
   AfterStruct:     true
   AfterUnion:      true
   AfterExternBlock: true
-  BeforeCatch:     false
+  BeforeCatch:     true
   BeforeElse:      true
   BeforeLambdaBody: true
   IndentBraces:    false
@@ -111,7 +112,7 @@ SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ artifacts
 xcuserdata
 .ccls-cache
 /SIDFactoryII/x64/Debug
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,8 @@ clean:
 
 .PHONY: run
 run: $(EXE)
-	cd $(ARTIFACTS_FOLDER) && ./$(APP_NAME)
+	cd $(ARTIFACTS_FOLDER) && ./$(APP_NAME) "../SIDFactoryII/music/Laxity/Laxity - Farfisa.sf2"
+
 
 .PHONY: debug
 debug: $(EXE)

--- a/SIDFactoryII/source/runtime/editor/keys/keyhook_setup.cpp
+++ b/SIDFactoryII/source/runtime/editor/keys/keyhook_setup.cpp
@@ -82,6 +82,7 @@ namespace Editor
 		definitions.push_back({ "Key.ScreenEdit.ToggleMuteChannel1", {{ SDLK_1, Keyboard::Control }} });
 		definitions.push_back({ "Key.ScreenEdit.ToggleMuteChannel2", {{ SDLK_2, Keyboard::Control }} });
 		definitions.push_back({ "Key.ScreenEdit.ToggleMuteChannel3", {{ SDLK_3, Keyboard::Control }} });
+		definitions.push_back({ "Key.ScreenEdit.ToggleOutputDevice", {{ SDLK_o, Keyboard::Alt }} });
 		definitions.push_back({ "Key.ScreenEdit.SetMarker", {{ SDLK_m, Keyboard::Control }} });
 		definitions.push_back({ "Key.ScreenEdit.GotoMarker", {{ SDLK_g, Keyboard::Control }} });
 		definitions.push_back({ "Key.ScreenEdit.QuickSave", {{ SDLK_s, Keyboard::Control }} });

--- a/SIDFactoryII/source/runtime/editor/screens/screen_edit.cpp
+++ b/SIDFactoryII/source/runtime/editor/screens/screen_edit.cpp
@@ -604,7 +604,6 @@ namespace Editor
 	{
 		ExecutionHandler::OutputDevice device = m_ExecutionHandler->GetOutputDevice();
 
-		// - Keeps playing last settings
 		if (device == ExecutionHandler::OutputDevice::RESID) {
 			device = ExecutionHandler::OutputDevice::ASID;
 		}

--- a/SIDFactoryII/source/runtime/editor/screens/screen_edit.h
+++ b/SIDFactoryII/source/runtime/editor/screens/screen_edit.h
@@ -116,6 +116,7 @@ namespace Editor
 		void DoPlayFromSelectedMarker();
 		void DoStop();
 		void DoToggleMute(unsigned int inChannel);
+		void DoToggleOutputDevice();
 		void DoClearAllMuteState();
 		void DoRestoreMuteState();
 		void DoMoveToEventPositionOfSelectedMarker();

--- a/SIDFactoryII/source/runtime/editor/screens/statusbar/status_bar_edit.cpp
+++ b/SIDFactoryII/source/runtime/editor/screens/statusbar/status_bar_edit.cpp
@@ -1,7 +1,9 @@
 #include "status_bar_edit.h"
 #include "foundation/graphics/textfield.h"
 #include "foundation/graphics/color.h"
+#include "runtime/execution/executionhandler.h"
 #include "utils/usercolors.h"
+#include <string>
 
 using namespace Utility;
 using namespace Foundation;
@@ -14,9 +16,11 @@ namespace Editor
 			const EditState& inEditState,
 			const DriverState& inDriverState,
 			const AuxilaryDataCollection& inAuxilaryDataCollection,
+			const Emulation::ExecutionHandler& inExecutionHandler,
 			std::function<void(Mouse::Button, int)> inOctaveMousePressCallback,
 			std::function<void(Mouse::Button, int)> inSharpFlatMousePressCallback,
 			std::function<void(Mouse::Button, int)> inSIDMousePressCallback,
+			std::function<void(Mouse::Button, int)> inOutputDevicePressCallback,
 			std::function<void(Mouse::Button, int)> inContextHighlightMousePressCallback,
 			std::function<void(Mouse::Button, int)> inFollowPlayerMousePressCallback
 	)
@@ -24,18 +28,21 @@ namespace Editor
 		, m_EditState(inEditState)
 		, m_DriverState(inDriverState)
 		, m_AuxilaryDataPlayMarkers(inAuxilaryDataCollection)
+		, m_ExecutionHandler(inExecutionHandler)
 	{
 		m_TextSectionOctave = std::make_shared<TextSection>(12, inOctaveMousePressCallback);
 		m_TextSectionSharpFlat = std::make_shared<TextSection>(15, inSharpFlatMousePressCallback);
 		m_TextSectionSID = std::make_shared<TextSection>(19, inSIDMousePressCallback);
 		m_TextSectionContextHighlight = std::make_shared<TextSection>(18, inContextHighlightMousePressCallback);
 		m_TextSectionFollowPlay = std::make_shared<TextSection>(15, inFollowPlayerMousePressCallback);
+		m_TextSectionOutputDevice = std::make_shared<TextSection>(17, inOutputDevicePressCallback);
 
 		m_TextSectionList.push_back(m_TextSectionOctave);
 		m_TextSectionList.push_back(m_TextSectionSharpFlat);
 		m_TextSectionList.push_back(m_TextSectionSID);
 		m_TextSectionList.push_back(m_TextSectionContextHighlight);
 		m_TextSectionList.push_back(m_TextSectionFollowPlay);
+		m_TextSectionList.push_back(m_TextSectionOutputDevice);
 	}
 
 	
@@ -43,8 +50,7 @@ namespace Editor
 	{
 
 	}
-
-
+	
 	void StatusBarEdit::UpdateInternal(int inDeltaTick, bool inNeedUpdate)
 	{
 		if (m_CachedEditState != m_EditState || inNeedUpdate)
@@ -75,6 +81,16 @@ namespace Editor
 			m_CachedSIDModel = sid_model;
 			m_CachedRegion = region;
 
+			m_NeedRefresh = true;
+		}
+
+		const Emulation::ExecutionHandler::OutputDevice outputDevice = m_ExecutionHandler.GetOutputDevice();
+
+		if (outputDevice != m_CachedOutputDevice || inNeedUpdate)
+		{
+			std::string output_device_string = (outputDevice == Emulation::ExecutionHandler::OutputDevice::ASID ? "ASID" : "RESID");
+			m_TextSectionOutputDevice->SetText("Output: " + output_device_string);
+			m_CachedOutputDevice = outputDevice;
 			m_NeedRefresh = true;
 		}
 

--- a/SIDFactoryII/source/runtime/editor/screens/statusbar/status_bar_edit.h
+++ b/SIDFactoryII/source/runtime/editor/screens/statusbar/status_bar_edit.h
@@ -8,6 +8,7 @@
 #include "runtime/editor/auxilarydata/auxilary_data_hardware_preferences.h"
 #include "runtime/editor/screens/statusbar/status_bar.h"
 #include "runtime/editor/driver/driver_state.h"
+#include "runtime/execution/executionhandler.h"
 #include <string>
 #include <functional>
 
@@ -27,9 +28,11 @@ namespace Editor
 			const EditState& inEditState,
 			const DriverState& inDriverState,
 			const AuxilaryDataCollection& inAuxilaryDataCollection,
+			const Emulation::ExecutionHandler& inExecutionHandler,
 			std::function<void(Foundation::Mouse::Button, int)> inOctaveMousePressCallback,
 			std::function<void(Foundation::Mouse::Button, int)> inSharpFlatMousePressCallback,
 			std::function<void(Foundation::Mouse::Button, int)> inSIDMousePressCallback,
+			std::function<void(Foundation::Mouse::Button, int)> inOuputDevicePressCallback,
 			std::function<void(Foundation::Mouse::Button, int)> inContextHighlightMousePressCallback,
 			std::function<void(Foundation::Mouse::Button, int)> inFollowPlayerMousePressCallback
 		);
@@ -48,10 +51,12 @@ namespace Editor
 		std::shared_ptr<TextSection> m_TextSectionSID;
 		std::shared_ptr<TextSection> m_TextSectionContextHighlight;
 		std::shared_ptr<TextSection> m_TextSectionFollowPlay;
+		std::shared_ptr<TextSection> m_TextSectionOutputDevice;
 
 		const EditState& m_EditState;
 		const AuxilaryDataCollection& m_AuxilaryDataPlayMarkers;
 		const DriverState& m_DriverState;
+		const Emulation::ExecutionHandler& m_ExecutionHandler;
 
 		EditState m_CachedEditState;
 		DriverState m_CachedDriverState;
@@ -59,5 +64,6 @@ namespace Editor
 		AuxilaryDataEditingPreferences::NotationMode m_CachedNotationMode;
 		AuxilaryDataHardwarePreferences::SIDModel m_CachedSIDModel;
 		AuxilaryDataHardwarePreferences::Region m_CachedRegion;
+		Emulation::ExecutionHandler::OutputDevice m_CachedOutputDevice; 
 	};
 }

--- a/SIDFactoryII/source/runtime/emulation/asid/asid.cpp
+++ b/SIDFactoryII/source/runtime/emulation/asid/asid.cpp
@@ -20,6 +20,11 @@ namespace Emulation
 		}
 	}
 
+
+	bool ASid::isPortOpen() {
+		return m_RtMidiOut->isPortOpen();
+	}
+
 	void ASid::SetMuted(bool inMuted)
 	{
 		if(inMuted == m_Muted)
@@ -30,17 +35,17 @@ namespace Emulation
 
 		m_Muted = inMuted;
 	}
-	
+
 	void ASid::SendSIDRegisterWriteOrderAndCycleInfo(std::vector<Editor::SIDWriteInformation> inSIDWriteInfoList)
 	{
 		#define WRITE_ORDER_UNUSED 0xff
-		
+
 		struct write_order
 		{
 			unsigned char ucIndex;
 			unsigned char ucCycles;
 		};
-		
+
 		// Physical out buffer, including protocol overhead
 		unsigned char ASidOutBuffer[ASID_NUM_REGS*2+4];
 

--- a/SIDFactoryII/source/runtime/emulation/asid/asid.cpp
+++ b/SIDFactoryII/source/runtime/emulation/asid/asid.cpp
@@ -21,7 +21,8 @@ namespace Emulation
 	}
 
 
-	bool ASid::isPortOpen() {
+	bool ASid::isPortOpen() 
+	{
 		return m_RtMidiOut->isPortOpen();
 	}
 

--- a/SIDFactoryII/source/runtime/emulation/asid/asid.h
+++ b/SIDFactoryII/source/runtime/emulation/asid/asid.h
@@ -14,8 +14,9 @@ namespace Emulation
 	public:
 		ASid(RtMidiOut* inRtMidiOut);
 
+		bool isPortOpen();
 		void SetMuted(bool inMuted);
-		
+
 		void SendSIDRegisterWriteOrderAndCycleInfo(std::vector<Editor::SIDWriteInformation> inSIDWriteInfoList);
 		void WriteToSIDRegister(unsigned char inSidReg, unsigned char inData);
 		void SendToDevice();
@@ -26,7 +27,7 @@ namespace Emulation
 
 		bool m_Muted = false;
 		RtMidiOut* m_RtMidiOut = nullptr;
-		
+
 		// Physical out buffer, including protocol overhead
 		unsigned char m_ASIDOutBuffer[ASID_NUM_REGS + 12];
 

--- a/SIDFactoryII/source/runtime/execution/executionhandler.cpp
+++ b/SIDFactoryII/source/runtime/execution/executionhandler.cpp
@@ -70,7 +70,6 @@ namespace Emulation
 
 		// Clear SID registers after last driver update
 		memset(m_SIDRegisterLastDriverUpdate.m_Buffer, 0, sizeof(m_SIDRegisterLastDriverUpdate.m_Buffer));
-
 	}
 
 	ExecutionHandler::~ExecutionHandler()
@@ -145,7 +144,8 @@ namespace Emulation
 		FeedPCM(inBuffer, inByteCount);
 	}
 
-	void ExecutionHandler::SetOutputDevice(const OutputDevice device) {
+	void ExecutionHandler::SetOutputDevice(const OutputDevice device)
+	{
 
 		if (m_OutputDevice == device)
 			return;
@@ -198,13 +198,14 @@ namespace Emulation
 
 				for (unsigned int i = 0; i < uiSamplesToCopy; ++i)
 				{
-					if (m_OutputDevice == ExecutionHandler::OutputDevice::RESID) 
+					if (m_OutputDevice == ExecutionHandler::OutputDevice::RESID)
 					{
 						const float fSample = static_cast<float>(pSource[i + m_SampleBufferReadCursor]) * m_OutputGain;
 						const float fClampedSample = fmin(sampleCeiling, fmax(fSample, sampleFloor));
 						pTarget[i] = static_cast<short>(fClampedSample);
 					}
-					else {
+					else
+					{
 						pTarget[i] = 0;
 					}
 				}

--- a/SIDFactoryII/source/runtime/execution/executionhandler.cpp
+++ b/SIDFactoryII/source/runtime/execution/executionhandler.cpp
@@ -1,5 +1,6 @@
 #include "executionhandler.h"
 
+#include "libraries/residfp/siddefs-fp.h"
 #include "runtime/emulation/cpuframecapture.h"
 #include "runtime/emulation/cpumos6510.h"
 #include "runtime/emulation/sid/sidproxy.h"
@@ -49,7 +50,8 @@ namespace Emulation
 		, m_SampleBufferWriteCursor(0)
 		, m_CPUFrameCounter(0)
 		, m_UpdateEnabled(false)
-    , m_ErrorState(false)
+		, m_ErrorState(false)
+		, m_OutputDevice(OutputDevice::RESID)
 	{
 		m_CyclesPerFrame = EMULATION_CYCLES_PER_FRAME_PAL;
 
@@ -68,6 +70,7 @@ namespace Emulation
 
 		// Clear SID registers after last driver update
 		memset(m_SIDRegisterLastDriverUpdate.m_Buffer, 0, sizeof(m_SIDRegisterLastDriverUpdate.m_Buffer));
+
 	}
 
 	ExecutionHandler::~ExecutionHandler()
@@ -142,6 +145,28 @@ namespace Emulation
 		FeedPCM(inBuffer, inByteCount);
 	}
 
+	void ExecutionHandler::SetOutputDevice(const OutputDevice device) {
+
+		if (m_OutputDevice == device)
+			return;
+
+		// if MIDI port is not open, do not switch to ASID
+		if (!m_ASID->isPortOpen())
+			return;
+
+		m_OutputDevice = device;
+
+		// mute/unmute ASID depending on its selection
+		m_ASID->SetMuted(m_OutputDevice != OutputDevice::ASID);
+
+		Utility::Logging::instance().Info("OutputDevice set to %s", m_OutputDevice == ExecutionHandler::OutputDevice::ASID ? "ASID" : "RESID");
+	}
+
+	const ExecutionHandler::OutputDevice ExecutionHandler::GetOutputDevice() const
+	{
+		return m_OutputDevice;
+	}
+
 	void ExecutionHandler::FeedPCM(void* inBuffer, unsigned int inByteCount)
 	{
 		m_FeedCount++;
@@ -173,9 +198,15 @@ namespace Emulation
 
 				for (unsigned int i = 0; i < uiSamplesToCopy; ++i)
 				{
-					const float fSample = static_cast<float>(pSource[i + m_SampleBufferReadCursor]) * m_OutputGain;
-					const float fClampedSample = fmin(sampleCeiling, fmax(fSample, sampleFloor));
-					pTarget[i] = static_cast<short>(fClampedSample);
+					if (m_OutputDevice == ExecutionHandler::OutputDevice::RESID) 
+					{
+						const float fSample = static_cast<float>(pSource[i + m_SampleBufferReadCursor]) * m_OutputGain;
+						const float fClampedSample = fmin(sampleCeiling, fmax(fSample, sampleFloor));
+						pTarget[i] = static_cast<short>(fClampedSample);
+					}
+					else {
+						pTarget[i] = 0;
+					}
 				}
 
 				// Forward the read cursor
@@ -391,7 +422,6 @@ namespace Emulation
 		}
 	}
 
-
 	void ExecutionHandler::CaptureNewFrame()
 	{
 		FOUNDATION_ASSERT(m_CPU != nullptr);
@@ -519,7 +549,7 @@ namespace Emulation
 			m_SIDProxy->Write((unsigned char)(capture.m_usReg & 0xff), capture.m_ucVal);
 			nCycle += deltaCycles;
 
-			if(m_ASID != nullptr)
+			if(m_OutputDevice == ExecutionHandler::OutputDevice::ASID &&  m_ASID != nullptr)
 				m_ASID->WriteToSIDRegister(static_cast<unsigned char>(capture.m_usReg & 0xff), capture.m_ucVal);
 		}
 

--- a/SIDFactoryII/source/runtime/execution/executionhandler.h
+++ b/SIDFactoryII/source/runtime/execution/executionhandler.h
@@ -106,7 +106,16 @@ namespace Emulation
 
 		// SID Write order info
 		void TellSIDWriteOrderInfo(std::vector<Editor::SIDWriteInformation> SIDWriteInfoList);
-	
+
+		enum class OutputDevice: int
+		{
+			RESID,
+			ASID
+		};
+
+		void SetOutputDevice(const OutputDevice device);
+		const OutputDevice GetOutputDevice() const;
+
 	private:
 		enum class ActionType : int
 		{
@@ -183,6 +192,7 @@ namespace Emulation
 		unsigned int m_SampleBufferSize;
 		short* m_SampleBuffer;
 		float m_OutputGain;
+		OutputDevice m_OutputDevice;
 	};
 }
 


### PR DESCRIPTION
- Alt-o toggles ASID/RESID
- Output device shown in status bar
  - Mouse clicking the status also switches
- No switch to ASID if the MIDI port is not open (when there are no MIDI devices for instance)

P.S. I did not do a nullptr check on m_ASID because imo it will never be null
  