### PR TITLE
Draft: 183 fullscreen support

### DIFF
--- a/SIDFactoryII/source/foundation/graphics/viewport.cpp
+++ b/SIDFactoryII/source/foundation/graphics/viewport.cpp
@@ -1,4 +1,5 @@
 #include "foundation/graphics/viewport.h"
+#include "SDL_video.h"
 #include "foundation/base/assert.h"
 #include "foundation/base/types.h"
 #include "foundation/graphics/drawfield.h"
@@ -46,6 +47,9 @@ namespace Foundation
 
 		m_RenderTarget = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_TARGET, m_ClientResolutionX, m_ClientResolutionY);
 		FOUNDATION_ASSERT(m_RenderTarget != nullptr);
+
+		SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+
 	}
 
 

--- a/SIDFactoryII/source/foundation/graphics/viewport.cpp
+++ b/SIDFactoryII/source/foundation/graphics/viewport.cpp
@@ -6,11 +6,9 @@
 #include "foundation/graphics/image.h"
 #include "foundation/graphics/imanaged.h"
 #include "foundation/graphics/textfield.h"
-#include "resources/data_char.h"
 #include "utils/config/configtypes.h"
 #include "utils/configfile.h"
 #include "utils/global.h"
-#include <iostream>
 
 using namespace Utility;
 using namespace Utility::Config;
@@ -49,7 +47,6 @@ namespace Foundation
 		FOUNDATION_ASSERT(m_RenderTarget != nullptr);
 
 		SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-
 	}
 
 
@@ -201,6 +198,8 @@ namespace Foundation
 		if (m_RenderTarget != nullptr)
 		{
 			SDL_SetRenderTarget(m_Renderer, nullptr);
+			SDL_SetRenderDrawColor(m_Renderer, 0, 0, 0, 255);
+			SDL_RenderClear(m_Renderer);
 
 			if (m_ShowOverlay)
 			{


### PR DESCRIPTION
Draft for fixing #183

Hardcoded fullscreen

An extra clearing of the screen is done in `viewport:End()` to eliminate noise in the 'letterboxed' areas. This seems like a hack; I would like to understand why crap is rendered there in the first place.

TODO:
- [ ] Fullscreen toggle with keyboard shortcut
- [ ] Config setting for starting fullscreen
- [ ] Find out why noise is rendered and maybe eliminate that