### PR TITLE
Make medium and high cpu levels configurable (#190)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ SIDFactoryII/*.vcxproj.user
 artifacts
 xcuserdata
 .ccls-cache
+.cache
 /SIDFactoryII/x64/Debug

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Please report issues in our [issue tracker](https://github.com/Chordian/sidfacto
 ![Commits since last
 release](https://img.shields.io/github/commits-since/chordian/sidfactory2/release-20231002)
 
+### Next release
+
+- Added [#190](https://github.com/Chordian/sidfactory2/issues/190)
+  Configuration options
+  for setting the limits of rastertime usage used to color frames orange or red in
+  the flightrecorder.
+  `Visualizer.CPU.Medium.Rasterlines` and `Visualizer.CPU.High.Rasterlines`
+
 ### Build 20231002
 
 - Added: [#102](https://github.com/Chordian/sidfactory2/issues/102) Visualizers

--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -88,6 +88,10 @@ Window.Scaling.Smooth               = 1         // If you set this to 1, scaling
 Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
                                                 // 0 = absolute value, 1 = alternative style
 
+Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
+Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+
+
 //
 // OVERLAY
 //

--- a/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.cpp
@@ -9,12 +9,16 @@
 #include "runtime/editor/cursor_control.h"
 #include "runtime/environmentdefines.h"
 #include "utils/usercolors.h"
+#include "utils/config/configtypes.h"
+#include "utils/configfile.h"
+#include "utils/global.h"
 
 #include "SDL_keycode.h"
 #include "foundation/base/assert.h"
 
 using namespace Foundation;
 using namespace Utility;
+using namespace Utility::Config;
 
 namespace Editor
 {
@@ -26,6 +30,9 @@ namespace Editor
 	{
 		FOUNDATION_ASSERT(inTextField != nullptr);
 		m_RequireRefresh = true;
+		ConfigFile& config = Global::instance().GetConfig();
+		m_CPUUsageMediumRasterlines = GetSingleConfigurationValue<ConfigValueInt>(config, "Visualizer.CPU.Medium.Rasterlines", 16);
+		m_CPUUsageHighRasterlines = GetSingleConfigurationValue<ConfigValueInt>(config, "Visualizer.CPU.High.Rasterlines", 24);
 	}
 
 
@@ -215,7 +222,7 @@ namespace Editor
 
 					const unsigned char scan_lines = static_cast<unsigned char>(frame_data.m_nCyclesSpend / EMULATION_CYCLES_PER_SCANLINE_PAL);
 
-					Color cycle_color = scan_lines < 0x10 ? color_cpu_usage_low : (scan_lines < 0x18 ? color_cpu_usage_medium : color_cpu_usage_high);
+					Color cycle_color = scan_lines < m_CPUUsageMediumRasterlines ? color_cpu_usage_low : (scan_lines < m_CPUUsageHighRasterlines ? color_cpu_usage_medium : color_cpu_usage_high);
 
 					m_TextField->PrintHexValue(x, y, is_uppercase, frame_number);
 					m_TextField->PrintChar(x + 4, y, ':');

--- a/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.h
+++ b/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.h
@@ -3,8 +3,6 @@
 #include "component_base.h"
 
 #include <memory>
-#include <string>
-#include <functional>
 
 namespace Foundation
 {
@@ -42,5 +40,7 @@ namespace Editor
 		unsigned int m_CursorPos;
 		unsigned int m_MaxCursorPos;
 		unsigned int m_TopVisible;
+        unsigned int m_CPUUsageMediumRasterlines;
+        unsigned int m_CPUUsageHighRasterlines;
 	};
 }

--- a/SIDFactoryII/source/runtime/editor/visualizer_components/vizualizer_component_emulation_state.cpp
+++ b/SIDFactoryII/source/runtime/editor/visualizer_components/vizualizer_component_emulation_state.cpp
@@ -3,10 +3,14 @@
 #include "foundation/graphics/drawfield.h"
 #include "runtime/editor/datasources/datasource_flightrecorder.h"
 #include "runtime/environmentdefines.h"
+#include "utils/global.h"
+#include "utils/config/configtypes.h"
+#include "utils/configfile.h"
 #include "utils/usercolors.h"
 
 using namespace Foundation;
 using namespace Utility;
+using namespace Utility::Config;
 
 namespace Editor
 {
@@ -22,6 +26,10 @@ namespace Editor
 		: VisualizerComponentBase(inID, inDrawField, inX, inY, inWidth, inHeight)
 		, m_DataSource(inDataSource)
 	{
+
+		ConfigFile& config = Global::instance().GetConfig();
+		m_CPUUsageMediumRasterlines = GetSingleConfigurationValue<ConfigValueInt>(config, "Visualizer.CPU.Medium.Rasterlines", 16);
+		m_CPUUsageHighRasterlines = GetSingleConfigurationValue<ConfigValueInt>(config, "Visualizer.CPU.High.Rasterlines", 24);
 
 	}
 
@@ -62,12 +70,7 @@ namespace Editor
 
 			const auto fetch_cycle_color = [&](const int inValue) -> const Color
 			{
-				if (inValue < 0x10)
-					return color_cpu_usage_low;
-				if (inValue < 0x18)
-					return color_cpu_usage_medium;
-
-				return color_cpu_usage_high;
+                return inValue < m_CPUUsageMediumRasterlines ? color_cpu_usage_low : (inValue < m_CPUUsageHighRasterlines ? color_cpu_usage_medium : color_cpu_usage_high);
 			};
 
 			DrawColoredFilled(fetch_cycle_value, fetch_cycle_color);

--- a/SIDFactoryII/source/runtime/editor/visualizer_components/vizualizer_component_emulation_state.h
+++ b/SIDFactoryII/source/runtime/editor/visualizer_components/vizualizer_component_emulation_state.h
@@ -37,5 +37,8 @@ namespace Editor
 		);
 
 		std::shared_ptr<DataSourceFlightRecorder> m_DataSource;
+
+        unsigned int m_CPUUsageMediumRasterlines;
+        unsigned int m_CPUUsageHighRasterlines;
 	};
 }

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -68,6 +68,10 @@ Window.Scaling.Smooth               = 1         // If you set this to 1, scaling
 Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
                                                 // 0 = absolute value, 1 = alternative style
 
+
+Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
+Visualizer.CPU.High.Rasterlines    = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+O
 //
 // OVERLAY
 //

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -70,7 +70,7 @@ Visualizer.PulseWidth.Style         = 0         // The way pulse width is visual
 
 
 Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
-Visualizer.CPU.High.Rasterlines    = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
 O
 //
 // OVERLAY


### PR DESCRIPTION
Added two configuration parameters to set the nr of rasterlines that are considered medium or high cpu usage in the flight recorder