### PR TITLE
Added max cycle and rasterline in flightrecorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ release](https://img.shields.io/github/commits-since/chordian/sidfactory2/releas
 
 ### Next release
 
-- Added [#190](https://github.com/Chordian/sidfactory2/issues/190)
+- Added: [#190](https://github.com/Chordian/sidfactory2/issues/190)
   Configuration options
   for setting the limits of rastertime usage used to color frames orange or red in
   the flightrecorder.
   `Visualizer.CPU.Medium.Rasterlines` and `Visualizer.CPU.High.Rasterlines`
+- Added: [#117](https://github.com/Chordian/sidfactory2/issues/117)
+  Flightrecorder now shows max cycles and rasterlines used over time, above
+  the column that shows cycle and rasterline counts for each frame.
 
 ### Build 20231002
 

--- a/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_flightrecorder.cpp
@@ -5,13 +5,13 @@
 #include "foundation/graphics/textfield.h"
 #include "foundation/input/mouse.h"
 #include "foundation/input/keyboard.h"
-#include "foundation/input/keyboard_utils.h"
 #include "runtime/editor/cursor_control.h"
 #include "runtime/environmentdefines.h"
 #include "utils/usercolors.h"
 #include "utils/config/configtypes.h"
 #include "utils/configfile.h"
 #include "utils/global.h"
+#include "utils/usercolors.h"
 
 #include "SDL_keycode.h"
 #include "foundation/base/assert.h"
@@ -208,6 +208,13 @@ namespace Editor
 			m_TextField->Print(2, 1, color_desc, "Frame Cycl SL  SC  Sy Freq Puls Wf ADSR  Sy Freq Puls Wf ADSR  Sy Freq Puls Wf ADSR  CutO RS BV");
 
 			const int x = 2;
+
+			const unsigned short max_cycles = static_cast<unsigned short>((*m_DataSource).GetCyclesSpendMax());
+			const unsigned char max_scan_lines = static_cast<unsigned char>(max_cycles / EMULATION_CYCLES_PER_SCANLINE_PAL);
+
+			Color max_color = max_scan_lines < m_CPUUsageMediumRasterlines ? color_cpu_usage_low : (max_scan_lines < m_CPUUsageHighRasterlines ? color_cpu_usage_medium : color_cpu_usage_high);
+			m_TextField->PrintHexValue(x + 6, 2, max_color, is_uppercase, max_cycles);
+			m_TextField->PrintHexValue(x + 11, 2, max_color, is_uppercase, max_scan_lines);
 
 			for (int i = 0; i < visible_row_count; ++i)
 			{

--- a/SIDFactoryII/source/runtime/editor/datasources/datasource_flightrecorder.cpp
+++ b/SIDFactoryII/source/runtime/editor/datasources/datasource_flightrecorder.cpp
@@ -72,5 +72,11 @@ namespace Editor
 
 		return index;
 	}
+
+	const unsigned int DataSourceFlightRecorder::GetCyclesSpendMax() const
+	{
+		FOUNDATION_ASSERT(m_FlightRecorder != nullptr);
+		return m_FlightRecorder->CyclesSpendMax();
+	}
 }
 

--- a/SIDFactoryII/source/runtime/editor/datasources/datasource_flightrecorder.h
+++ b/SIDFactoryII/source/runtime/editor/datasources/datasource_flightrecorder.h
@@ -19,6 +19,7 @@ namespace Editor
 		const int GetSize() const override;
 		const bool IsRecording() const;
 		const unsigned int GetNewestRecordingIndex() const;
+		const unsigned int GetCyclesSpendMax() const;
 
 		bool PushDataToSource() override { return true; }
 

--- a/SIDFactoryII/source/runtime/execution/flightrecorder.cpp
+++ b/SIDFactoryII/source/runtime/execution/flightrecorder.cpp
@@ -75,6 +75,7 @@ namespace Emulation
 
 		m_TopIndex = 0;
 		m_RecordedFrameCount = 0;
+		m_CyclesSpendMax = 0;
 
 		for (unsigned int i = 0; i < m_FrameCapacity; ++i)
 			m_Frames[i].Reset();
@@ -124,6 +125,12 @@ namespace Emulation
 		return m_RecordedFrameCount;
 	}
 
+	unsigned int FlightRecorder::CyclesSpendMax() const
+	{
+		FOUNDATION_ASSERT(m_Locked);
+		return m_CyclesSpendMax;
+	}
+
 	//------------------------------------------------------------------------------------------------
 
 	const FlightRecorder::Frame& FlightRecorder::GetFrame(unsigned int inIndex) const
@@ -153,6 +160,10 @@ namespace Emulation
 
 		inFrameData.m_nFrameNumber = inFrame;
 		inFrameData.m_nCyclesSpend = inCyclesSpend;
+
+		if (inCyclesSpend > m_CyclesSpendMax) {
+			m_CyclesSpendMax = inCyclesSpend;
+		}
 
 		inMemory->GetData(0xd400, &inFrameData.m_SIDData, 0x19);
 

--- a/SIDFactoryII/source/runtime/execution/flightrecorder.h
+++ b/SIDFactoryII/source/runtime/execution/flightrecorder.h
@@ -52,6 +52,7 @@ namespace Emulation
 		void Record(unsigned int inFrame, CPUMemory* inMemory, unsigned int inCyclesSpend);
 
 		unsigned int RecordedFrameCount() const;
+		unsigned int CyclesSpendMax() const;
 		const Frame& GetFrame(unsigned int inIndex) const;
 		const Frame& GetNewestFrame() const;
 
@@ -69,6 +70,7 @@ namespace Emulation
 
 		unsigned int m_TopIndex;
 		unsigned int m_RecordedFrameCount;
+		unsigned int m_CyclesSpendMax;
 
 		unsigned int m_FrameCapacity;
 


### PR DESCRIPTION
In flightrecorder, between the header and the actual frame values, the running maximum for cycles spent and rasterlines spent is shown in the low/medium/high cpu color.