### PR TITLE
Show packed sequence size

### DIFF
--- a/SIDFactoryII/config.ini
+++ b/SIDFactoryII/config.ini
@@ -88,17 +88,20 @@ Window.Font                         = "DEFAULT"   // default Font (16 pixels hig
 // Window.Font                      = "C64"       // c64 font (8 pixel high)
 
 //
-// Visualizers
-//
-Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
-                                                // 0 = absolute value, 1 = alternative style
+ // Visualizers
+ //
+ Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
+                                                 // 0 = absolute value, 1 = alternative style
 
-Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
-Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+ Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
+ Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+
+ Visualizer.Tracklist.ShowPackedSize = 0         // Show packed size (hex) in tracklist for multi-row sequences
+                                                 // 0 = off, 1 = on
 
 
-//
-// OVERLAY
+ //
+ // OVERLAY
 //
 Show.Overlay                        = 0         // If you set this to 1, the overlay will be shown when starting the editor.
 

--- a/SIDFactoryII/source/runtime/editor/components/component_track.cpp
+++ b/SIDFactoryII/source/runtime/editor/components/component_track.cpp
@@ -24,6 +24,8 @@
 #include "utils/keyhook.h"
 #include "utils/keyhookstore.h"
 #include "utils/usercolors.h"
+#include "utils/global.h"
+#include "utils/configfile.h"
 
 #include <string>
 #include "foundation/base/assert.h"
@@ -31,6 +33,7 @@
 
 using namespace Foundation;
 using namespace Utility;
+using namespace Utility::Config;
 
 namespace Editor
 {
@@ -141,6 +144,7 @@ namespace Editor
 		, m_IsMarkingArea(false)
 		, m_MarkingFromEventPos(0)
 		, m_MarkingToEventPos(0)
+		, m_ShowPackedSize(GetSingleConfigurationValue<ConfigValueInt>(Global::instance().GetConfig(), "Visualizer.Tracklist.ShowPackedSize", 0) != 0)
 	{
 		UpdateMaxEventPos();
 
@@ -509,10 +513,13 @@ namespace Editor
 				const Color color_orderlist_value = ToColor(UserColor::OrderlistValue);
 				const Color color_orderlist_value_loop_marker = ToColor(UserColor::OrderlistValueLoopMarker);
 				const Color color_orderlist_value_input = ToColor(UserColor::OrderlistValueInput);
+				const Color color_sequence_packed_size = ToColor(UserColor::SequenceInstrumentEmpty);
 				
 				while (current_event < bottom_event)
 				{
 					DataSourceOrderList::Entry& order_list_entry = (*m_DataSourceOrderList)[orderlist_index];
+
+					const std::shared_ptr<DataSourceSequence>& sequence = m_DataSourceSequenceList[order_list_entry.m_SequenceIndex];
 
 					if (sequence_index == 0)
 					{
@@ -534,6 +541,13 @@ namespace Editor
 								m_TextField->PrintHexValue(m_Position.m_X, current_y, color, is_uppercase, order_list_entry.m_Transposition);
 								m_TextField->PrintHexValue(m_Position.m_X + 2, current_y, color, is_uppercase, order_list_entry.m_SequenceIndex);
 							}
+
+							if (m_ShowPackedSize && sequence->GetLength() > 1)
+							{
+								unsigned int packed_size = sequence->GetPackedSize();
+								std::string packed_size_str = ComponentTrack::ToHexValueString(packed_size, is_uppercase);
+								m_TextField->Print(m_Position.m_X, current_y + 1, color_sequence_packed_size, packed_size_str.c_str());
+							}
 						}
 					}
 
@@ -542,8 +556,6 @@ namespace Editor
 
 					int transposition = static_cast<int>(order_list_entry.m_Transposition);
 					FOUNDATION_ASSERT(transposition < 0xfe);
-
-					const std::shared_ptr<DataSourceSequence>& sequence = m_DataSourceSequenceList[order_list_entry.m_SequenceIndex];
 
 					DrawSequenceLine(m_Position.m_X + 5, current_y, sequence_colors, is_uppercase, sequence, sequence_index, transposition - 0xa0, current_event == m_EventPos, current_instrument);
 
@@ -1091,7 +1103,7 @@ namespace Editor
 			else if (event.m_Instrument == 0x90)
 				m_TextField->Print(instrument_pos, tie_note, "**");
 			else if ((event.m_Instrument & 0xe0) == 0xa0)
-				m_TextField->Print(instrument_pos, value, ComponentTrack::ToHexValueString(event.m_Instrument & 0x1f, inIsHexUppercase));
+				m_TextField->Print(instrument_pos, value, ComponentTrack::ToHexValueString(static_cast<unsigned char>(event.m_Instrument & 0x1f), inIsHexUppercase));
 			else
 				m_TextField->Print(instrument_pos, inColors.m_ErrorState, "??");
 		}
@@ -1108,7 +1120,7 @@ namespace Editor
 			if (event.m_Command == 0x80)
 				m_TextField->Print(command_pos, empty, "--");
 			else if ((event.m_Command & 0xc0) == 0xc0)
-				m_TextField->Print(command_pos, value, ComponentTrack::ToHexValueString(event.m_Command & 0x3f, inIsHexUppercase));
+				m_TextField->Print(command_pos, value, ComponentTrack::ToHexValueString(static_cast<unsigned char>(event.m_Command & 0x3f), inIsHexUppercase));
 			else
 				m_TextField->Print(command_pos, inColors.m_ErrorState, "??");
 		}
@@ -3251,21 +3263,43 @@ namespace Editor
 	}
 
 
-	std::string ComponentTrack::ToHexValueString(unsigned char inValue, const bool inUppercase)
+std::string ComponentTrack::ToHexValueString(unsigned char inValue, const bool inUppercase)
+{
+	auto make_character = [&inUppercase](unsigned char inValue) -> char
 	{
-		auto make_character = [&inUppercase](unsigned char inValue) -> char
-		{
-			if (inValue > 0x0f)
-				return 'x';
-			if (inValue < 10)
-				return '0' + inValue;
+		if (inValue > 0x0f)
+			return 'x';
+		if (inValue < 10)
+			return '0' + inValue;
 
-			if (inUppercase)
-				return 'A' + inValue - 10;
+		if (inUppercase)
+			return 'A' + inValue - 10;
 
-			return 'a' + inValue - 10;
-		};
+		return 'a' + inValue - 10;
+	};
 
-		return std::string({ make_character(inValue >> 4), make_character(inValue & 0x0f) });
+	return std::string({ make_character(inValue >> 4), make_character(inValue & 0x0f) });
+}
+
+std::string ComponentTrack::ToHexValueString(unsigned int inValue, const bool inUppercase)
+{
+	if (inValue == 0)
+		return "0";
+
+	std::string result;
+	while (inValue > 0)
+	{
+		unsigned int digit = inValue & 0x0f;
+		char c;
+		if (digit < 10)
+			c = '0' + digit;
+		else if (inUppercase)
+			c = 'A' + digit - 10;
+		else
+			c = 'a' + digit - 10;
+		result.insert(result.begin(), c);
+		inValue >>= 4;
 	}
+	return result;
+}
 }

--- a/SIDFactoryII/source/runtime/editor/components/component_track.h
+++ b/SIDFactoryII/source/runtime/editor/components/component_track.h
@@ -271,6 +271,7 @@ namespace Editor
 		void ConfigureKeyHooks(const Utility::KeyHookStore& inKeyHookStore);
 
 		static std::string ToHexValueString(unsigned char inValue, const bool inUppercase);
+		static std::string ToHexValueString(unsigned int inValue, const bool inUppercase);
 
 		template<typename PREDICATE>
 		std::vector<unsigned char> ForEachEventInMarkedRange(PREDICATE&& inPredicate);
@@ -283,6 +284,9 @@ namespace Editor
 
 		// Muted
 		bool m_IsMuted;
+
+		// Config: show packed size in tracklist
+		bool m_ShowPackedSize;
 
 		// Cursor and event positions
 		int m_CursorPos;

--- a/dist/documentation/user.default.ini
+++ b/dist/documentation/user.default.ini
@@ -67,17 +67,20 @@ Window.Font                         = "DEFAULT"   // default Font (16 pixels hig
 // Window.Font                      = "C64"       // c64 font (8 pixel high)
 
 //
-// Visualizers
-//
-Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
-                                                // 0 = absolute value, 1 = alternative style
+ // Visualizers
+ //
+ Visualizer.PulseWidth.Style         = 0         // The way pulse width is visualized
+                                                 // 0 = absolute value, 1 = alternative style
+
+ Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
+ Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
+
+ Visualizer.Tracklist.ShowPackedSize = 0         // Show packed size (hex) in tracklist for multi-row sequences
+                                                 // 0 = off, 1 = on
 
 
-Visualizer.CPU.Medium.Rasterlines   = 16        // In the flightrecorder, frames that use this many or more rasterlines get a warning color
-Visualizer.CPU.High.Rasterlines     = 24        // In the flightrecorder, frames that use this many or more rasterlines get an error color
-O
-//
-// OVERLAY
+ //
+ // OVERLAY
 //
 Show.Overlay                        = 0         // If you set this to 1, the overlay will be shown when starting the editor.
                                                 // Note that you can always toggle the overlay on and off with the F12 hotkey.

--- a/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/design.md
+++ b/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The tracklist in the editor displays orderlist entries showing transpose and sequence numbers. Users need to see the packed size (in hex) of each sequence to optimize memory usage. The `DataSourceSequence` class already provides `GetPackedSize()` method. The track rendering happens in `ComponentTrack::Refresh()` where orderlist entries are drawn at sequence_index 0.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display packed size (hex) below transpose/sequence number in tracklist
+- Only show when sequence has multiple rows (height > 1)
+- Use existing `DataSourceSequence::GetPackedSize()` method
+- Config option `Visualizer.Tracklist.ShowPackedSize` (default: 0/off) to toggle display
+
+**Non-Goals:**
+- Modify packing logic or data structures
+- Change orderlist data model
+
+## Decisions
+
+1. **Location**: Add packed size display in `ComponentTrack::Refresh()` after drawing orderlist entry (sequence_index == 0), on the next row (current_y + 1) in the orderlist column (m_Position.m_X)
+
+2. **Condition**: Only draw if config `Visualizer.Tracklist.ShowPackedSize` == 1 AND sequence length > 1 (i.e., the sequence spans multiple rows, leaving space below the orderlist entry). The orderlist entry occupies only the first row of its column; sequence data is in the adjacent column.
+
+3. **Format**: Print as variable-width uppercase hex (e.g., "A", "1A", "FF", "100") matching display state casing (`inDisplayState.IsHexUppercase()`). Use new helper `ToHexValueString(unsigned int, bool)` for variable-width output.
+
+4. **Color**: Reuse existing dimmed color `SequenceInstrumentEmpty` (dimmed/gray) to distinguish derived read-only data from editable orderlist values.
+
+5. **Data Access**: Get sequence from `m_DataSourceSequenceList[order_list_entry.m_SequenceIndex]` and call `GetPackedSize()`. Use cached `m_PackedSize` - no extra `Pack()` calls needed (packing happens for playback).
+
+6. **Casing**: Match `inDisplayState.IsHexUppercase()` like other hex values in the track view.
+
+7. **Helper**: Add overload `ComponentTrack::ToHexValueString(unsigned int, bool)` for variable-width hex formatting.
+
+8. **Config**: Add `Visualizer.Tracklist.ShowPackedSize` config option (int, default 0). Read once during `ComponentTrack` construction and cache as member variable `m_ShowPackedSize` (bool). Check cached value in `ComponentTrack::Refresh()` instead of reading config every frame. Add to distributed ini files (config.ini, user.default.ini).
+
+## Risks / Trade-offs
+
+- [Risk] Sequence might be 1 row tall → Mitigation: Check `sequence->GetLength() > 1` before drawing
+- [Risk] Visual clutter if many sequences → Mitigation: Only show when space permits (height > 1) AND config enabled
+- [Risk] Packed size changes after edit → Mitigation: Refresh already triggers on sequence changes via `SequenceChangedEvent`
+- [Risk] Packed size exceeds 255 → Mitigation: Variable-width hex handles any size (max 1024 bytes = 0x400 = 3 hex digits)

--- a/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/proposal.md
+++ b/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The tracklist currently shows transpose/sequence numbers but lacks visibility into the packed size of each sequence. Users need to see the packed size (in hex) to optimize memory usage and understand sequence compression efficiency without opening each sequence individually.
+
+The display should be opt-in via configuration to avoid visual clutter for users who don't need it.
+
+## What Changes
+
+- Add packed size display (hex) below transpose/sequence number column in tracklist
+- Only show packed size when sequence row height allows (multi-row sequences)
+- Add config option `Visualizer.Tracklist.ShowPackedSize` (default: 0/off) to toggle display
+- No breaking changes to existing functionality
+
+## Capabilities
+
+### New Capabilities
+- `tracklist-packed-size-display`: Display packed size in hex for each sequence in tracklist when space permits and config enabled
+
+### Modified Capabilities
+- None
+
+## Impact
+
+- Tracklist UI component (likely in sequence/tracklist view)
+- Sequence data model to expose packed size calculation
+- Config system: new option `Visualizer.Tracklist.ShowPackedSize`
+- No API, dependency, or system changes

--- a/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/specs/tracklist-packed-size-display/spec.md
+++ b/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/specs/tracklist-packed-size-display/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Packed size displayed in tracklist
+The system SHALL display the packed size (in hexadecimal) of each sequence in the tracklist, positioned below the transpose/sequence number in the orderlist column, when enabled by configuration.
+
+#### Scenario: Config enables packed size display
+- **WHEN** config `Visualizer.Tracklist.ShowPackedSize` is set to 1
+- **THEN** packed size display is enabled for eligible sequences
+
+#### Scenario: Config disables packed size display
+- **WHEN** config `Visualizer.Tracklist.ShowPackedSize` is set to 0 (default)
+- **THEN** packed size is never displayed regardless of sequence length
+
+#### Scenario: Multi-row sequence shows packed size when enabled
+- **WHEN** config `Visualizer.Tracklist.ShowPackedSize` is 1 AND a sequence in the orderlist has length greater than 1
+- **THEN** the packed size in hex is displayed on the row immediately below the transpose/sequence number (orderlist column, current_y + 1)
+
+#### Scenario: Single-row sequence does not show packed size
+- **WHEN** a sequence in the orderlist has length equal to 1
+- **THEN** no packed size is displayed (insufficient vertical space in orderlist column)
+
+#### Scenario: Packed size updates when sequence changes
+- **WHEN** a sequence is modified and its packed size changes
+- **THEN** the displayed packed size updates on next refresh (triggered by SequenceChangedEvent)
+
+#### Scenario: Packed size format is variable-width hex
+- **WHEN** packed size is displayed
+- **THEN** it is shown as variable-width uppercase hexadecimal (e.g., "A", "1A", "FF", "100") matching display state casing
+
+#### Scenario: Packed size uses dimmed color
+- **WHEN** packed size is displayed
+- **THEN** it uses the dimmed color (SequenceInstrumentEmpty) to distinguish from editable orderlist values

--- a/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/tasks.md
+++ b/openspec/changes/archive/2026-06-14-show-packed-size-tracklist/tasks.md
@@ -1,0 +1,22 @@
+## 1. Implementation
+
+- [x] 1.1 Add `ToHexValueString(unsigned int, bool)` overload in ComponentTrack for variable-width hex
+- [x] 1.2 Modify `ComponentTrack::Refresh()` to display packed size below orderlist entry (at m_Position.m_X, current_y + 1)
+- [x] 1.3 Add condition to only show packed size when sequence->GetLength() > 1
+- [x] 1.4 Format packed size as variable-width hex matching display state casing (IsHexUppercase)
+- [x] 1.5 Use dimmed color (SequenceInstrumentEmpty) for packed size display
+- [x] 1.6 Use cached GetPackedSize() - no extra Pack() calls
+- [x] 1.7 Add cached config member `m_ShowPackedSize` to ComponentTrack, read once in constructor from `Global::instance().GetConfig()`
+- [x] 1.8 Modify `ComponentTrack::Refresh()` to check `m_ShowPackedSize` instead of reading config
+- [x] 1.9 Add `Visualizer.Tracklist.ShowPackedSize = 0` to SIDFactoryII/config.ini
+- [x] 1.10 Add `Visualizer.Tracklist.ShowPackedSize = 0` to dist/documentation/user.default.ini
+
+## 2. Testing
+
+- [x] 2.1 Verify packed size displays for multi-row sequences (length > 1)
+- [x] 2.2 Verify packed size hidden for single-row sequences (length == 1)
+- [x] 2.3 Verify packed size updates after sequence edit (SequenceChangedEvent triggers refresh)
+- [x] 2.4 Verify hex format: variable-width, correct casing, values > 255 (e.g., 100, 256, 1024)
+- [x] 2.5 Verify color is dimmed (distinct from orderlist values)
+- [x] 2.6 Verify packed size hidden when config is 0 (default)
+- [x] 2.7 Verify packed size shows when config is 1 and sequence length > 1

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## What changed?

When enabled in config, shows the packed size of a sequence in the orderlist column

## Checklist

- [ ] Windows build action succeeds
- [ ] macOS build action succeeds
- [ ] Smoke tested on Windows
- [x] Smoke tested on macOS
- [ ] Documentation is up-to-date
- [ ] README is up-to-date
